### PR TITLE
Add SuperAdmin role handling

### DIFF
--- a/backend/src/main/java/codigocreativo/uy/servidorapp/filtros/JwtTokenFilter.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/filtros/JwtTokenFilter.java
@@ -219,8 +219,8 @@ public class JwtTokenFilter implements ContainerRequestFilter {
 
         // Verificar si es una modificación de usuario
         if (path.equals("/usuarios/modificar")) {
-            // Solo permitir que administradores modifiquen a otros administradores
-            if (perfil.equals("Administrador")) {
+            // Solo permitir que administradores o super administradores modifiquen a otros administradores
+            if (perfil.equals("Administrador") || perfil.equals("SuperAdmin")) {
                 return true;
             } else {
                 LOGGER.log(Level.WARNING, "Usuario con perfil {0} intentando modificar - Acceso denegado", perfil);

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/UsuarioBean.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/UsuarioBean.java
@@ -38,6 +38,7 @@ public class UsuarioBean implements UsuarioRemote {
     private static final int EDAD_MINIMA = 18;
     private static final String QUERY_USUARIO_POR_EMAIL = "SELECT u FROM Usuario u WHERE u.email = :email";
     private static final String ADMINISTRADOR = "Administrador";
+    private static final String SUPER_ADMIN = "SuperAdmin";
 
     @Override
     public void crearUsuario(UsuarioDto u) throws ServiciosException {
@@ -356,7 +357,7 @@ public class UsuarioBean implements UsuarioRemote {
         
         // Verificar que el solicitante sea administrador o aux administrativo
         String perfilSolicitante = solicitante.getIdPerfil().getNombrePerfil();
-        if (!perfilSolicitante.equals(ADMINISTRADOR) && !perfilSolicitante.equals("Aux Administrativo")) {
+        if (!perfilSolicitante.equals(ADMINISTRADOR) && !perfilSolicitante.equals(SUPER_ADMIN) && !perfilSolicitante.equals("Aux Administrativo")) {
             throw new ServiciosException("Requiere ser Administrador o Aux Administrativo para inactivar usuarios");
         }
         
@@ -372,7 +373,8 @@ public class UsuarioBean implements UsuarioRemote {
         }
         
         // Verificar que no se esté intentando inactivar a otro administrador
-        if (usuarioAInactivar.getIdPerfil().getNombrePerfil().equals(ADMINISTRADOR)) {
+        if (usuarioAInactivar.getIdPerfil().getNombrePerfil().equals(ADMINISTRADOR) ||
+                usuarioAInactivar.getIdPerfil().getNombrePerfil().equals(SUPER_ADMIN)) {
             throw new ServiciosException("No puedes inactivar a otro administrador");
         }
     }
@@ -432,7 +434,8 @@ public class UsuarioBean implements UsuarioRemote {
             throw new ServiciosException("Usuario solicitante no encontrado");
         }
         
-        if (!solicitante.getIdPerfil().getNombrePerfil().equals(ADMINISTRADOR)) {
+        if (!solicitante.getIdPerfil().getNombrePerfil().equals(ADMINISTRADOR)
+                && !solicitante.getIdPerfil().getNombrePerfil().equals(SUPER_ADMIN)) {
             throw new ServiciosException("Solo los administradores pueden modificar usuarios");
         }
         

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/ws/UsuarioResource.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/ws/UsuarioResource.java
@@ -44,6 +44,7 @@ public class UsuarioResource {
     private static final String BEARER = "bearer";
     private static final String PERFIL = "perfil";
     private static final String ADMINISTRADOR = "Administrador";
+    private static final String SUPER_ADMIN = "SuperAdmin";
     private static final String MESSAGE = "message";
     private static final String ERROR = "error";
 
@@ -283,7 +284,7 @@ public class UsuarioResource {
             String perfilSolicitante = claims.get(PERFIL, String.class);
 
             // Verificar que el usuario es administrador o aux administrativo
-            if (!ADMINISTRADOR.equals(perfilSolicitante) && !"Aux Administrativo".equals(perfilSolicitante)) {
+            if (!ADMINISTRADOR.equals(perfilSolicitante) && !SUPER_ADMIN.equals(perfilSolicitante) && !"Aux Administrativo".equals(perfilSolicitante)) {
                 return Response.status(Response.Status.FORBIDDEN)
                         .entity("{\"message\":\"Requiere ser Administrador o Aux Administrativo para inactivar usuarios\"}")
                         .build();
@@ -305,7 +306,7 @@ public class UsuarioResource {
             }
 
             // Verificar que no se está inactivando a otro administrador
-            if (ADMINISTRADOR.equals(usuarioAInactivar.getIdPerfil().getNombrePerfil())) {
+            if (ADMINISTRADOR.equals(usuarioAInactivar.getIdPerfil().getNombrePerfil()) || SUPER_ADMIN.equals(usuarioAInactivar.getIdPerfil().getNombrePerfil())) {
                 return Response.status(Response.Status.FORBIDDEN)
                         .entity("{\"message\":\"No puedes inactivar a otro administrador\"}")
                         .build();

--- a/frontend/src/components/Usuarios/Login/Registrar.tsx
+++ b/frontend/src/components/Usuarios/Login/Registrar.tsx
@@ -28,6 +28,7 @@ export default function Registrar() {
         { type: Number, value: 3, label: 'Ingeniero Biomedico' },
         { type: Number, value: 4, label: 'Tecnico' },
         { type: Number, value: 5, label: 'Tecnologo' },
+        { type: Number, value: 6, label: 'SuperAdmin' },
     ];
 
     useEffect(() => {

--- a/frontend/src/components/Usuarios/crearUsuario.tsx
+++ b/frontend/src/components/Usuarios/crearUsuario.tsx
@@ -30,7 +30,8 @@ export default function Registrar() {
         { type: Number, value: 2, label: 'Aux Administrativo' },
         { type: Number, value: 3, label: 'Ingeniero Biomedico' },
         { type: Number, value: 4, label: 'Tecnico' },
-        { type: Number, value: 5, label: 'Tecnologo' }
+        { type: Number, value: 5, label: 'Tecnologo' },
+        { type: Number, value: 6, label: 'SuperAdmin' }
     ];
 
     useEffect(() => {


### PR DESCRIPTION
## Summary
- allow SuperAdmin to perform admin operations
- accept SuperAdmin profile in JWT filter
- extend inactivation checks to include SuperAdmin
- expose SuperAdmin role in the frontend user forms

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6882cd0c1da48324b421987959da53d9