### PR TITLE
Fix JSON references to avoid recursion

### DIFF
--- a/backend/src/main/java/codigocreativo/uy/servidorapp/dtos/EquipoDto.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/dtos/EquipoDto.java
@@ -3,6 +3,7 @@ package codigocreativo.uy.servidorapp.dtos;
 import codigocreativo.uy.servidorapp.entidades.Equipo;
 import codigocreativo.uy.servidorapp.enumerados.Estados;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.json.bind.annotation.JsonbTransient;
 
 import java.io.Serializable;
@@ -23,6 +24,7 @@ public class EquipoDto implements Serializable {
     private ProveedoresEquipoDto idProveedor;
     private PaisDto idPais;
     private ModelosEquipoDto idModelo;
+    @JsonManagedReference
     private Set<EquiposUbicacioneDto> equiposUbicaciones = new LinkedHashSet<>();
     private UbicacionDto idUbicacion;
     private String nombre;
@@ -265,7 +267,6 @@ public class EquipoDto implements Serializable {
         this.idModelo = idModelo;
         return this;
     }
-    @JsonbTransient
     public Set<EquiposUbicacioneDto> getEquiposUbicaciones() {
         return equiposUbicaciones;
     }

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/dtos/EquiposUbicacioneDto.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/dtos/EquiposUbicacioneDto.java
@@ -3,12 +3,14 @@ package codigocreativo.uy.servidorapp.dtos;
 import java.io.Serializable;
 import java.time.LocalDate;
 import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 
 /**
  * DTO for {@link codigocreativo.uy.servidorapp.entidades.EquiposUbicacione}
  */
 public class EquiposUbicacioneDto implements Serializable {
     private Long id;
+    @JsonBackReference
     private EquipoDto idEquipo;
     private UbicacionDto idUbicacion;
     private LocalDate fecha;


### PR DESCRIPTION
## Summary
- manage Equipo->EquiposUbicacione serialization with `@JsonManagedReference`
- mark back reference from EquiposUbicacione to Equipo with `@JsonBackReference`
- remove unused `@JsonbTransient` from the getter

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.jacoco:jacoco-maven-plugin from central)*

------
https://chatgpt.com/codex/tasks/task_e_6882ff27ba448324a5a6bae6b89e3ebf