### PR TITLE
Fix dark mode style in CreateDynamic

### DIFF
--- a/frontend/src/components/Helpers/CreateDynamic.tsx
+++ b/frontend/src/components/Helpers/CreateDynamic.tsx
@@ -192,7 +192,7 @@ const CreateDynamic: React.FC<Props> = ({ fields, createUrl, successMessage, err
   };
 
   return (
-    <div className="p-6 bg-white rounded-lg shadow-md">
+    <div className="p-6 bg-white dark:bg-boxdark rounded-lg shadow-md">
       <form onSubmit={handleSubmit}>
         {fields.map(f => (
           <div className="mb-4" key={f.accessor}>


### PR DESCRIPTION
## Summary
- update CreateDynamic container to support dark mode
- ensure modal also handles dark background

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688333ba7908832498a4c47140035942