### PR TITLE
Align Equipo filters

### DIFF
--- a/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/EquipoBean.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/EquipoBean.java
@@ -157,6 +157,7 @@ public class EquipoBean implements EquipoRemote {
         agregarCondicion(queryStr, filtros, "proveedor", "LOWER(e.idProveedor.nombre) LIKE LOWER(:proveedor)");
         agregarCondicion(queryStr, filtros, "fechaAdquisicion", "e.fechaAdquisicion = :fechaAdquisicion");
         agregarCondicion(queryStr, filtros, "identificacionInterna", "LOWER(e.idInterno) LIKE LOWER(:identificacionInterna)");
+        agregarCondicion(queryStr, filtros, "estado", "e.estado = :estado");
         agregarCondicion(queryStr, filtros, "ubicacion", "LOWER(e.idUbicacion.nombre) LIKE LOWER(:ubicacion)");
     }
 

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/ws/EquipoResource.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/ws/EquipoResource.java
@@ -232,6 +232,7 @@ public class EquipoResource {
             @Parameter(description = "Marca del equipo") @QueryParam("marca") String marca,
             @Parameter(description = "Modelo del equipo") @QueryParam("modelo") String modelo,
             @Parameter(description = "Número de serie del equipo") @QueryParam("numeroSerie") String numeroSerie,
+            @Parameter(description = "Estado del equipo") @QueryParam("estado") String estado,
             @Parameter(description = "País de origen del equipo") @QueryParam("paisOrigen") String paisOrigen,
             @Parameter(description = "Proveedor del equipo") @QueryParam("proveedor") String proveedor,
             @Parameter(description = "Fecha de adquisición del equipo") @QueryParam("fechaAdquisicion") String fechaAdquisicion,
@@ -243,10 +244,11 @@ public class EquipoResource {
         if (marca != null) filtros.put("marca", marca);
         if (modelo != null) filtros.put("modelo", modelo);
         if (numeroSerie != null) filtros.put("numeroSerie", numeroSerie);
+        if (estado != null) filtros.put("estado", estado);
         if (paisOrigen != null) filtros.put("paisOrigen", paisOrigen);
         if (proveedor != null) filtros.put("proveedor", proveedor);
         if (fechaAdquisicion != null) filtros.put("fechaAdquisicion", fechaAdquisicion);
-        if (idInterno != null) filtros.put("idInterno", idInterno);
+        if (idInterno != null) filtros.put("identificacionInterna", idInterno);
         if (ubicacion != null) filtros.put("ubicacion", ubicacion);
 
         return this.er.obtenerEquiposFiltrado(filtros);

--- a/frontend/src/components/Paginas/Equipos/Listar.tsx
+++ b/frontend/src/components/Paginas/Equipos/Listar.tsx
@@ -102,9 +102,9 @@ const ListarEquipos: React.FC = () => {
           objectFit: "cover"
         }
       },
-      { header: "ID Interno", accessor: "idInterno", type: "text", filterable: true },
+      { header: "ID Interno", accessor: "idInterno", type: "text", filterable: true, filterKey: "identificacionInterna" },
     { header: "Nombre", accessor: "nombre", type: "text", filterable: true },
-    { header: "Número de Serie", accessor: "nroSerie", type: "text", filterable: true },
+    { header: "Número de Serie", accessor: "nroSerie", type: "text", filterable: true, filterKey: "numeroSerie" },
     { 
       header: "Tipo", 
       accessor: (row) => row.idTipo?.nombreTipo || "-",


### PR DESCRIPTION
## Summary
- sync filter naming between backend and frontend
- add estado filtering for Equipo

## Testing
- `mvn test` *(fails: PluginResolutionException)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68834d4eb91c8324a17f67a24dd9a8da