### PR TITLE
Add new filter params for usuarios

### DIFF
--- a/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/UsuarioBean.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/UsuarioBean.java
@@ -263,6 +263,9 @@ public class UsuarioBean implements UsuarioRemote {
         if (filtros.containsKey(EMAIL)) {
             queryBuilder.append(" AND LOWER(u.email) LIKE LOWER(:email)");
         }
+        if (filtros.containsKey("cedula")) {
+            queryBuilder.append(" AND LOWER(u.cedula) LIKE LOWER(:cedula)");
+        }
         
         // Check if estado is valid before adding to query
         boolean estadoValido = false;
@@ -281,6 +284,12 @@ public class UsuarioBean implements UsuarioRemote {
         if (filtros.containsKey("tipoUsuario")) {
             queryBuilder.append(" AND u.idPerfil.nombrePerfil = :tipoUsuario");
         }
+        if (filtros.containsKey("rol")) {
+            queryBuilder.append(" AND u.idPerfil.nombrePerfil = :rol");
+        }
+        if (filtros.containsKey("modulo")) {
+            queryBuilder.append(" AND EXISTS (SELECT fp FROM FuncionalidadesPerfiles fp JOIN fp.funcionalidad f WHERE fp.perfil = u.idPerfil AND LOWER(f.ruta) LIKE LOWER(:modulo))");
+        }
         
         var query = em.createQuery(queryBuilder.toString(), Usuario.class);
         
@@ -296,11 +305,20 @@ public class UsuarioBean implements UsuarioRemote {
         if (filtros.containsKey(EMAIL)) {
             query.setParameter(EMAIL, "%" + filtros.get(EMAIL) + "%");
         }
+        if (filtros.containsKey("cedula")) {
+            query.setParameter("cedula", "%" + filtros.get("cedula") + "%");
+        }
         if (estadoValido) {
             query.setParameter("estado", estadoEnum);
         }
         if (filtros.containsKey("tipoUsuario")) {
             query.setParameter("tipoUsuario", filtros.get("tipoUsuario"));
+        }
+        if (filtros.containsKey("rol")) {
+            query.setParameter("rol", filtros.get("rol"));
+        }
+        if (filtros.containsKey("modulo")) {
+            query.setParameter("modulo", "%" + filtros.get("modulo") + "%");
         }
         
         return usuarioMapper.toDto(query.getResultList(), new CycleAvoidingMappingContext());

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/ws/UsuarioResource.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/ws/UsuarioResource.java
@@ -346,6 +346,9 @@ public class UsuarioResource {
                                             @Parameter(description = "Apellido del usuario") @QueryParam("apellido") String apellido,
                                             @Parameter(description = "Nombre de usuario") @QueryParam("nombreUsuario") String nombreUsuario,
                                             @Parameter(description = "Email del usuario") @QueryParam("email") String email,
+                                            @Parameter(description = "Cédula del usuario") @QueryParam("cedula") String cedula,
+                                            @Parameter(description = "Rol del usuario") @QueryParam("rol") String rol,
+                                            @Parameter(description = "Módulo") @QueryParam("modulo") String modulo,
                                             @Parameter(description = "Tipo de perfil del usuario") @QueryParam("perfil") String tipoUsuario,
                                             @Parameter(description = "Estado del usuario") @QueryParam("estado") String estado) {
 
@@ -355,6 +358,9 @@ public class UsuarioResource {
             if (apellido != null) filtros.put("apellido", apellido);
             if (nombreUsuario != null) filtros.put("nombreUsuario", nombreUsuario);
             if (email != null) filtros.put(EMAIL, email);
+            if (cedula != null) filtros.put("cedula", cedula);
+            if (rol != null) filtros.put("rol", rol);
+            if (modulo != null) filtros.put("modulo", modulo);
 
             if (estado == null || estado.isEmpty()) {
                 filtros.put("estado", "ACTIVO");

--- a/frontend/src/components/Paginas/Usuarios/Listar.tsx
+++ b/frontend/src/components/Paginas/Usuarios/Listar.tsx
@@ -53,21 +53,28 @@ const ListarUsuarios: React.FC = () => {
   }, []);
 
   const columns: Column<Usuario>[] = [
-    { header: "Cédula", accessor: "cedula", type: "text", filterable: true },
+    { header: "Cédula", accessor: "cedula", type: "text", filterable: true, filterKey: "cedula" },
     { header: "Nombre", accessor: "nombre", type: "text", filterable: true },
     { header: "Apellido", accessor: "apellido", type: "text", filterable: true },
     { header: "Nombre de Usuario", accessor: "nombreUsuario", type: "text", filterable: true },
     { header: "Email", accessor: "email", type: "email", filterable: true },
-    { 
-      header: "Rol", 
+    {
+      header: "Módulo",
+      accessor: () => "",
+      type: "text",
+      filterable: true,
+      filterKey: "modulo",
+    },
+    {
+      header: "Rol",
       accessor: (row: Usuario) => row.idPerfil?.nombrePerfil || "",
-      type: "dropdown", 
+      type: "dropdown",
       options: perfiles.map(perfil => ({ 
         value: perfil.nombrePerfil, 
         label: perfil.nombrePerfil 
       })), 
       filterable: true,
-      filterKey: "tipoUsuario" // Campo específico para el filtro en la URL
+      filterKey: "rol" // Campo específico para el filtro en la URL
     },
     { header: "Estado", accessor: "estado", type: "text", filterable: true },
   ];


### PR DESCRIPTION
## Summary
- extend `/usuarios/filtrar` endpoint with cedula, rol and modulo parameters
- support cedula, rol and modulo in `UsuarioBean.obtenerUsuariosFiltrado`
- map frontend filters to cedula, rol and modulo

## Testing
- `mvn -q test` *(fails: could not resolve jacoco-maven-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68834daf3ed883248fa553b1e63d9bff