### PR TITLE
Add filtering for interventions

### DIFF
--- a/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/IntervencionRemote.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/IntervencionRemote.java
@@ -19,4 +19,14 @@ public interface IntervencionRemote {
 
     List<IntervencionDto> obtenerPorRangoDeFecha(LocalDateTime fechaDesde, LocalDateTime fechaHasta, Long idEquipo) throws ServiciosException;
     Map<String, Long> obtenerCantidadPorTipo(LocalDateTime fechaDesde, LocalDateTime fechaHasta, Long idTipo) throws ServiciosException;
+
+    /**
+     * Obtiene las intervenciones aplicando filtros opcionales
+     *
+     * @param technician nombre o usuario del técnico que realizó la intervención
+     * @param type       nombre del tipo de intervención
+     * @param estado     estado del técnico
+     * @return lista de intervenciones que cumplen con los filtros
+     */
+    List<IntervencionDto> filtrarIntervenciones(String technician, String type, String estado) throws ServiciosException;
 }

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/ws/IntervencionesResource.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/ws/IntervencionesResource.java
@@ -120,4 +120,17 @@ public class IntervencionesResource {
         LocalDateTime hasta = fechaHasta != null ? LocalDateTime.parse(fechaHasta) : null;
         return this.er.obtenerCantidadPorTipo(desde, hasta, idTipo);
     }
+
+    @GET
+    @Path("/filtrar")
+    @Operation(summary = "Filtrar intervenciones", description = "Filtra las intervenciones según técnico, tipo y estado", tags = { "Intervenciones" })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Lista filtrada correctamente", content = @Content(schema = @Schema(implementation = IntervencionDto.class)))
+    })
+    public List<IntervencionDto> filtrar(
+            @Parameter(description = "Técnico que realizó la intervención") @QueryParam("technician") String technician,
+            @Parameter(description = "Tipo de intervención") @QueryParam("type") String type,
+            @Parameter(description = "Estado del técnico") @QueryParam("estado") String estado) throws ServiciosException {
+        return this.er.filtrarIntervenciones(technician, type, estado);
+    }
 }

--- a/frontend/src/components/Paginas/Intervenciones/Listar.tsx
+++ b/frontend/src/components/Paginas/Intervenciones/Listar.tsx
@@ -1,6 +1,5 @@
 "use client";
-import React, { useEffect, useState } from "react";
-import fetcher from "@/components/Helpers/Fetcher";
+import React, { useState } from "react";
 import DynamicTable, { Column } from "@/components/Helpers/DynamicTable";
 import { formatDateForDisplay } from "@/components/Helpers/DateUtils";
 
@@ -32,22 +31,6 @@ interface Intervencion {
 const ListarIntervenciones: React.FC = () => {
   const [intervenciones, setIntervenciones] = useState<Intervencion[]>([]);
   const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
-
-  const handleSearch = async (filters: Record<string, string>) => {
-    setLoading(true);
-    try {
-      const data = await fetcher<Intervencion[]>("/intervenciones/listar", { method: "GET" });
-      setIntervenciones(data);
-    } catch (err: any) {
-      setError(err.message);
-    }
-    setLoading(false);
-  };
-
-  useEffect(() => {
-    handleSearch({});
-  }, []);
 
   const columns: Column<Intervencion>[] = [
     { 
@@ -80,11 +63,12 @@ const ListarIntervenciones: React.FC = () => {
       type: "text", 
       filterable: true 
     },
-    { 
-      header: "Tipo de Intervención", 
+    {
+      header: "Tipo de Intervención",
       accessor: (row) => row.idTipo?.nombreTipo || "-",
       type: "text",
-      filterable: true
+      filterable: true,
+      filterKey: "type"
     },
     { 
       header: "Equipo", 
@@ -92,11 +76,12 @@ const ListarIntervenciones: React.FC = () => {
       type: "text",
       filterable: true
     },
-    { 
-      header: "Usuario", 
+    {
+      header: "Usuario",
       accessor: (row) => row.idUsuario ? `${row.idUsuario.nombre} ${row.idUsuario.apellido}` : "-",
       type: "text",
-      filterable: true
+      filterable: true,
+      filterKey: "technician"
     },
     { 
       header: "Comentarios", 
@@ -125,22 +110,17 @@ const ListarIntervenciones: React.FC = () => {
       )}
 
       <div className="p-4 md:p-6 xl:p-7.5">
-        {loading ? (
-          <div className="flex justify-center items-center h-32">
-            <div className="text-gray-600">Cargando...</div>
-          </div>
-        ) : (
-          <DynamicTable
-            columns={columns}
-            data={intervenciones}
-            withFilters={true}
-            onSearch={handleSearch}
-            withActions={true}
-            basePath="/intervenciones"
-            // No hay endpoint de eliminación directa en el backend actual
-            // deleteUrl="/intervenciones/eliminar"
-          />
-        )}
+        <DynamicTable
+          columns={columns}
+          data={intervenciones}
+          withFilters={true}
+          filterUrl="/intervenciones/filtrar"
+          onDataUpdate={setIntervenciones}
+          withActions={true}
+          basePath="/intervenciones"
+          // No hay endpoint de eliminación directa en el backend actual
+          // deleteUrl="/intervenciones/eliminar"
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add filtering method to `IntervencionRemote`
- implement dynamic query in `IntervencionBean`
- expose new `/intervenciones/filtrar` endpoint
- use `filterUrl` in Intervenciones list component

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68834daf8c488324a01490c436fa7cf7