### PR TITLE
Add filters for brand name and provider country

### DIFF
--- a/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/MarcasModeloBean.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/MarcasModeloBean.java
@@ -106,16 +106,24 @@ public class MarcasModeloBean implements MarcasModeloRemote{
         );
     }
 
-    public List<MarcasModeloDto> obtenerMarcasPorEstadoLista(Estados estado) throws ServiciosException {
+    public List<MarcasModeloDto> obtenerMarcasPorEstadoLista(Estados estado, String nombre) throws ServiciosException {
         if (estado == null) {
             throw new ServiciosException("El estado es obligatorio para filtrar");
         }
-        
-        return marcasModeloMapper.toDto(
-            em.createQuery("SELECT marcasModelo FROM MarcasModelo marcasModelo WHERE marcasModelo.estado = :estado ORDER BY marcasModelo.id DESC", MarcasModelo.class)
-                .setParameter("estado", estado.name())
-                .getResultList()
-        );
+
+        String jpql = "SELECT marcasModelo FROM MarcasModelo marcasModelo WHERE marcasModelo.estado = :estado";
+        if (nombre != null && !nombre.trim().isEmpty()) {
+            jpql += " AND UPPER(marcasModelo.nombre) LIKE UPPER(:nombre)";
+        }
+        jpql += " ORDER BY marcasModelo.id DESC";
+
+        var query = em.createQuery(jpql, MarcasModelo.class)
+                .setParameter("estado", estado.name());
+        if (nombre != null && !nombre.trim().isEmpty()) {
+            query.setParameter("nombre", "%" + nombre.trim() + "%");
+        }
+
+        return marcasModeloMapper.toDto(query.getResultList());
     }
 
     @Override

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/MarcasModeloRemote.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/MarcasModeloRemote.java
@@ -11,6 +11,6 @@ public interface MarcasModeloRemote {
     public void modificarMarcasModelo(MarcasModeloDto marcasModelo) throws ServiciosException;
     public MarcasModeloDto obtenerMarca(Long id) throws ServiciosException;
     public List<MarcasModeloDto> obtenerMarcasLista();
-    public List<MarcasModeloDto> obtenerMarcasPorEstadoLista(Estados estado) throws ServiciosException;
+    List<MarcasModeloDto> obtenerMarcasPorEstadoLista(Estados estado, String nombre) throws ServiciosException;
     public void eliminarMarca(Long id) throws ServiciosException;
 }

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/ProveedoresEquipoRemote.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/ProveedoresEquipoRemote.java
@@ -14,5 +14,5 @@ public interface ProveedoresEquipoRemote {
     List<ProveedoresEquipoDto> obtenerProveedores();
     void eliminarProveedor(Long id);
     List<ProveedoresEquipoDto> buscarProveedores(String nombre, Estados estado);
-    List<ProveedoresEquipoDto> filtrarProveedores(String nombre, String estado);
+    List<ProveedoresEquipoDto> filtrarProveedores(String nombre, String estado, String pais);
 }

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/ws/MarcaResource.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/ws/MarcaResource.java
@@ -124,10 +124,10 @@ public class MarcaResource {
         @ApiResponse(responseCode = "200", description = "Lista de marcas filtrada correctamente"),
         @ApiResponse(responseCode = "400", description = "Estado inválido", content = @Content(schema = @Schema(example = "{\"error\": \"Estado inválido\"}")))
     })
-    public Response filtrarPorEstado(@QueryParam("estado") String estado) {
+    public Response filtrarPorEstado(@QueryParam("estado") String estado, @QueryParam("nombre") String nombre) {
         try {
             Estados estadoEnum = Estados.valueOf(estado);
-            return Response.ok(er.obtenerMarcasPorEstadoLista(estadoEnum)).build();
+            return Response.ok(er.obtenerMarcasPorEstadoLista(estadoEnum, nombre)).build();
         } catch (Exception e) {
             return Response.status(400).entity(Map.of(ERROR, e.getMessage())).build();
         }

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/ws/ProveedoresResource.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/ws/ProveedoresResource.java
@@ -110,9 +110,11 @@ public class ProveedoresResource {
             @ApiResponse(responseCode = "200", description = "Lista de proveedores filtrada correctamente", content = @Content(schema = @Schema(implementation = ProveedoresEquipoDto.class))),
             @ApiResponse(responseCode = "400", description = "Estado inválido", content = @Content(schema = @Schema(example = "{\"error\": \"Estado inválido\"}")))
     })
-    public Response filtrarProveedores(@QueryParam("nombre") String nombre, @QueryParam("estado") String estado) {
+    public Response filtrarProveedores(@QueryParam("nombre") String nombre,
+                                       @QueryParam("estado") String estado,
+                                       @QueryParam("pais") String pais) {
         try {
-            return Response.ok(this.er.filtrarProveedores(nombre, estado)).build();
+            return Response.ok(this.er.filtrarProveedores(nombre, estado, pais)).build();
         } catch (Exception e) {
             return Response.status(400).entity(java.util.Map.of(ERROR, "Estado inválido: " + e.getMessage())).build();
         }

--- a/backend/src/test/java/codigocreativo/uy/servidorapp/servicios/ProveedoresEquipoBeanTest.java
+++ b/backend/src/test/java/codigocreativo/uy/servidorapp/servicios/ProveedoresEquipoBeanTest.java
@@ -148,7 +148,7 @@ class ProveedoresEquipoBeanTest {
         when(query.getResultList()).thenReturn(List.of(new ProveedoresEquipo()));
         when(proveedoresEquipoMapper.toDto(anyList())).thenReturn(List.of(new ProveedoresEquipoDto()));
         
-        List<ProveedoresEquipoDto> result = bean.filtrarProveedores(null, "ACTIVO");
+        List<ProveedoresEquipoDto> result = bean.filtrarProveedores(null, "ACTIVO", null);
         
         assertNotNull(result);
         verify(query).setParameter("estado", "ACTIVO");
@@ -163,7 +163,7 @@ class ProveedoresEquipoBeanTest {
         when(query.getResultList()).thenReturn(List.of(new ProveedoresEquipo()));
         when(proveedoresEquipoMapper.toDto(anyList())).thenReturn(List.of(new ProveedoresEquipoDto()));
         
-        List<ProveedoresEquipoDto> result = bean.filtrarProveedores("test", null);
+        List<ProveedoresEquipoDto> result = bean.filtrarProveedores("test", null, null);
         
         assertNotNull(result);
         verify(query).setParameter("nombre", "%test%");
@@ -178,11 +178,26 @@ class ProveedoresEquipoBeanTest {
         when(query.getResultList()).thenReturn(List.of(new ProveedoresEquipo()));
         when(proveedoresEquipoMapper.toDto(anyList())).thenReturn(List.of(new ProveedoresEquipoDto()));
         
-        List<ProveedoresEquipoDto> result = bean.filtrarProveedores("test", "ACTIVO");
+        List<ProveedoresEquipoDto> result = bean.filtrarProveedores("test", "ACTIVO", null);
         
         assertNotNull(result);
         verify(query).setParameter("estado", "ACTIVO");
         verify(query).setParameter("nombre", "%test%");
+    }
+
+    @Test
+    void testFiltrarProveedores_porPais() {
+        @SuppressWarnings("unchecked")
+        TypedQuery<ProveedoresEquipo> query = mock(TypedQuery.class);
+        when(em.createQuery(anyString(), eq(ProveedoresEquipo.class))).thenReturn(query);
+        when(query.setParameter(anyString(), any())).thenReturn(query);
+        when(query.getResultList()).thenReturn(List.of(new ProveedoresEquipo()));
+        when(proveedoresEquipoMapper.toDto(anyList())).thenReturn(List.of(new ProveedoresEquipoDto()));
+
+        List<ProveedoresEquipoDto> result = bean.filtrarProveedores(null, null, "Uruguay");
+
+        assertNotNull(result);
+        verify(query).setParameter("pais", "%Uruguay%");
     }
 
     @Test
@@ -193,7 +208,7 @@ class ProveedoresEquipoBeanTest {
         when(query.getResultList()).thenReturn(List.of(new ProveedoresEquipo()));
         when(proveedoresEquipoMapper.toDto(anyList())).thenReturn(List.of(new ProveedoresEquipoDto()));
         
-        List<ProveedoresEquipoDto> result = bean.filtrarProveedores(null, null);
+        List<ProveedoresEquipoDto> result = bean.filtrarProveedores(null, null, null);
         
         assertNotNull(result);
         // Verifica que se llama al método obtenerProveedores() (sin filtro)
@@ -203,7 +218,7 @@ class ProveedoresEquipoBeanTest {
     @Test
     void testFiltrarProveedores_estadoInvalido() {
         assertThrows(IllegalArgumentException.class, () -> {
-            bean.filtrarProveedores(null, "ESTADO_INVALIDO");
+            bean.filtrarProveedores(null, "ESTADO_INVALIDO", null);
         });
     }
 } 

--- a/backend/src/test/java/codigocreativo/uy/servidorapp/ws/ProveedoresResourceTest.java
+++ b/backend/src/test/java/codigocreativo/uy/servidorapp/ws/ProveedoresResourceTest.java
@@ -142,56 +142,68 @@ class ProveedoresResourceTest {
     @Test
     void testFiltrarProveedores_soloNombre() {
         List<ProveedoresEquipoDto> expectedList = Arrays.asList(proveedorDto);
-        when(er.filtrarProveedores("test", null)).thenReturn(expectedList);
+        when(er.filtrarProveedores("test", null, null)).thenReturn(expectedList);
 
-        Response response = resource.filtrarProveedores("test", null);
+        Response response = resource.filtrarProveedores("test", null, null);
 
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         assertEquals(expectedList, response.getEntity());
-        verify(er, times(1)).filtrarProveedores("test", null);
+        verify(er, times(1)).filtrarProveedores("test", null, null);
     }
 
     @Test
     void testFiltrarProveedores_soloEstado() {
         List<ProveedoresEquipoDto> expectedList = Arrays.asList(proveedorDto);
-        when(er.filtrarProveedores(null, "ACTIVO")).thenReturn(expectedList);
+        when(er.filtrarProveedores(null, "ACTIVO", null)).thenReturn(expectedList);
 
-        Response response = resource.filtrarProveedores(null, "ACTIVO");
+        Response response = resource.filtrarProveedores(null, "ACTIVO", null);
 
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         assertEquals(expectedList, response.getEntity());
-        verify(er, times(1)).filtrarProveedores(null, "ACTIVO");
+        verify(er, times(1)).filtrarProveedores(null, "ACTIVO", null);
     }
 
     @Test
     void testFiltrarProveedores_nombreYEstado() {
         List<ProveedoresEquipoDto> expectedList = Arrays.asList(proveedorDto);
-        when(er.filtrarProveedores("test", "ACTIVO")).thenReturn(expectedList);
+        when(er.filtrarProveedores("test", "ACTIVO", null)).thenReturn(expectedList);
 
-        Response response = resource.filtrarProveedores("test", "ACTIVO");
+        Response response = resource.filtrarProveedores("test", "ACTIVO", null);
 
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         assertEquals(expectedList, response.getEntity());
-        verify(er, times(1)).filtrarProveedores("test", "ACTIVO");
+        verify(er, times(1)).filtrarProveedores("test", "ACTIVO", null);
+    }
+
+    @Test
+    void testFiltrarProveedores_porPais() {
+        List<ProveedoresEquipoDto> expectedList = Arrays.asList(proveedorDto);
+        when(er.filtrarProveedores(null, null, "Uruguay")).thenReturn(expectedList);
+
+        Response response = resource.filtrarProveedores(null, null, "Uruguay");
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        assertEquals(expectedList, response.getEntity());
+        verify(er, times(1)).filtrarProveedores(null, null, "Uruguay");
     }
 
     @Test
     void testFiltrarProveedores_sinFiltros() {
         List<ProveedoresEquipoDto> expectedList = Arrays.asList(proveedorDto);
-        when(er.filtrarProveedores(null, null)).thenReturn(expectedList);
+        when(er.filtrarProveedores(null, null, null)).thenReturn(expectedList);
 
-        Response response = resource.filtrarProveedores(null, null);
+        Response response = resource.filtrarProveedores(null, null, null);
 
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         assertEquals(expectedList, response.getEntity());
-        verify(er, times(1)).filtrarProveedores(null, null);
+        verify(er, times(1)).filtrarProveedores(null, null, null);
     }
 
     @Test
     void testFiltrarProveedores_estadoInvalido() {
-        when(er.filtrarProveedores(null, "ESTADO_INVALIDO")).thenThrow(new IllegalArgumentException("Estado inválido"));
+        when(er.filtrarProveedores(null, "ESTADO_INVALIDO", null)).thenThrow(new IllegalArgumentException("Estado inválido"));
 
-        Response response = resource.filtrarProveedores(null, "ESTADO_INVALIDO");
+        Response response = resource.filtrarProveedores(null, "ESTADO_INVALIDO", null);
 
         assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
         Map<String, String> entity = (Map<String, String>) response.getEntity();

--- a/frontend/src/components/Paginas/Marcas/Listar.tsx
+++ b/frontend/src/components/Paginas/Marcas/Listar.tsx
@@ -17,7 +17,7 @@ const ListarMarcas: React.FC = () => {
   // Removemos handleSearch y useEffect ya que DynamicTable manejará la carga automática
 
   const columns: Column<Marca>[] = [
-    { header: "Nombre", accessor: "nombre", type: "text", filterable: false },
+    { header: "Nombre", accessor: "nombre", type: "text", filterable: true },
     { 
       header: "Estado", 
       accessor: "estado",

--- a/frontend/src/components/Paginas/Proveedores/Listar.tsx
+++ b/frontend/src/components/Paginas/Proveedores/Listar.tsx
@@ -21,7 +21,7 @@ const ListarProveedores: React.FC = () => {
 
   const columns: Column<Proveedor>[] = useMemo(() => [
     { header: "Nombre", accessor: "nombre", type: "text", filterable: true },
-    { header: "País", accessor: (row) => row.pais?.nombre || "-", type: "text", filterable: false },
+    { header: "País", accessor: (row) => row.pais?.nombre || "-", type: "text", filterable: true, filterKey: "pais" },
     { header: "Estado", accessor: "estado", type: "text", filterable: true }
   ], []);
 


### PR DESCRIPTION
## Summary
- allow brand filtering by name and state
- support provider filtering by country
- adjust front-end tables to include new filters
- update unit tests

## Testing
- `mvn test` *(fails: jacoco plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68834db3eb608324962412c8864438cc