### PR TITLE
Implement generic filter endpoints

### DIFF
--- a/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/PerfilBean.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/PerfilBean.java
@@ -159,5 +159,32 @@ public class PerfilBean implements PerfilRemote {
                 .getResultList());
     }
 
+    @Override
+    public List<PerfilDto> filtrarPerfiles(String nombre, String estado) {
+        Estados estadoEnum = null;
+        if (estado != null && !estado.trim().isEmpty()) {
+            estadoEnum = Estados.valueOf(estado);
+        }
+
+        StringBuilder jpql = new StringBuilder("SELECT p FROM Perfil p WHERE 1=1");
+        if (nombre != null && !nombre.trim().isEmpty()) {
+            jpql.append(" AND UPPER(p.nombrePerfil) LIKE UPPER(:nombre)");
+        }
+        if (estadoEnum != null) {
+            jpql.append(" AND p.estado = :estado");
+        }
+        jpql.append(" ORDER BY p.nombrePerfil ASC");
+
+        var query = em.createQuery(jpql.toString(), Perfil.class);
+        if (nombre != null && !nombre.trim().isEmpty()) {
+            query.setParameter("nombre", "%" + nombre.trim() + "%");
+        }
+        if (estadoEnum != null) {
+            query.setParameter("estado", estadoEnum);
+        }
+
+        return perfilMapper.toDtoList(query.getResultList());
+    }
+
     
 }

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/PerfilRemote.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/PerfilRemote.java
@@ -16,5 +16,6 @@ public interface PerfilRemote {
     public List<PerfilDto> obtenerPerfiles();
     public List<PerfilDto> listarPerfilesPorNombre(String nombre);
     public List<PerfilDto> listarPerfilesPorEstado(Estados estado);
+    List<PerfilDto> filtrarPerfiles(String nombre, String estado);
 
 }

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/TipoIntervencioneBean.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/TipoIntervencioneBean.java
@@ -52,4 +52,31 @@ public class TipoIntervencioneBean implements TipoIntervencioneRemote {
                 .setParameter("id", id)
                 .executeUpdate();
     }
+
+    @Override
+    public List<TiposIntervencioneDto> filtrarTiposIntervenciones(String nombre, String estado) {
+        codigocreativo.uy.servidorapp.enumerados.Estados estadoEnum = null;
+        if (estado != null && !estado.trim().isEmpty()) {
+            estadoEnum = codigocreativo.uy.servidorapp.enumerados.Estados.valueOf(estado);
+        }
+
+        StringBuilder jpql = new StringBuilder("SELECT t FROM TiposIntervencione t WHERE 1=1");
+        if (nombre != null && !nombre.trim().isEmpty()) {
+            jpql.append(" AND UPPER(t.nombreTipo) LIKE UPPER(:nombre)");
+        }
+        if (estadoEnum != null) {
+            jpql.append(" AND t.estado = :estado");
+        }
+        jpql.append(" ORDER BY t.nombreTipo ASC");
+
+        var query = em.createQuery(jpql.toString(), TiposIntervencione.class);
+        if (nombre != null && !nombre.trim().isEmpty()) {
+            query.setParameter("nombre", "%" + nombre.trim() + "%");
+        }
+        if (estadoEnum != null) {
+            query.setParameter("estado", estadoEnum.name());
+        }
+
+        return tiposIntervencioneMapper.toDto(query.getResultList());
+    }
 }

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/TipoIntervencioneRemote.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/TipoIntervencioneRemote.java
@@ -12,4 +12,5 @@ public interface TipoIntervencioneRemote {
     void crearTipoIntervencion(TiposIntervencioneDto tipoIntervencion);
     void modificarTipoIntervencion(TiposIntervencioneDto tipoIntervencion);
     void eliminarTipoIntervencion(Long id);
+    List<TiposIntervencioneDto> filtrarTiposIntervenciones(String nombre, String estado);
 }

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/TiposEquipoBean.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/TiposEquipoBean.java
@@ -126,6 +126,33 @@ public class TiposEquipoBean implements TiposEquipoRemote{
         List<TiposEquipo> tiposEquipos = em.createQuery("SELECT t FROM TiposEquipo t ORDER BY t.nombreTipo ASC", TiposEquipo.class).getResultList();
         return tiposEquipoMapper.toDto(tiposEquipos);
     }
+
+    @Override
+    public List<TiposEquipoDto> filtrarTiposEquipo(String nombre, String estado) {
+        Estados estadoEnum = null;
+        if (estado != null && !estado.trim().isEmpty()) {
+            estadoEnum = Estados.valueOf(estado);
+        }
+
+        StringBuilder jpql = new StringBuilder("SELECT t FROM TiposEquipo t WHERE 1=1");
+        if (nombre != null && !nombre.trim().isEmpty()) {
+            jpql.append(" AND UPPER(t.nombreTipo) LIKE UPPER(:nombre)");
+        }
+        if (estadoEnum != null) {
+            jpql.append(" AND t.estado = :estado");
+        }
+        jpql.append(" ORDER BY t.nombreTipo ASC");
+
+        var query = em.createQuery(jpql.toString(), TiposEquipo.class);
+        if (nombre != null && !nombre.trim().isEmpty()) {
+            query.setParameter("nombre", "%" + nombre.trim() + "%");
+        }
+        if (estadoEnum != null) {
+            query.setParameter("estado", estadoEnum.name());
+        }
+
+        return tiposEquipoMapper.toDto(query.getResultList());
+    }
     
     /**
      * Valida que el nombre del tipo de equipo sea único en la base de datos

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/TiposEquipoRemote.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/TiposEquipoRemote.java
@@ -13,4 +13,5 @@ public interface TiposEquipoRemote {
     public void eliminarTiposEquipo(Long id) throws ServiciosException;
     public TiposEquipoDto obtenerPorId(Long id) throws ServiciosException;
     public List<TiposEquipoDto> listarTiposEquipo();
+    List<TiposEquipoDto> filtrarTiposEquipo(String nombre, String estado);
 }

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/ws/PerfilResource.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/ws/PerfilResource.java
@@ -158,6 +158,16 @@ public class PerfilResource {
     }
 
     @GET
+    @Path("/filtrar")
+    @Operation(summary = "Filtrar perfiles", description = "Filtra los perfiles por nombre y/o estado", tags = { "Perfiles" })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Lista de perfiles filtrada correctamente", content = @Content(schema = @Schema(implementation = PerfilDto.class)))
+    })
+    public List<PerfilDto> filtrarPerfiles(@QueryParam("nombre") String nombre, @QueryParam("estado") String estado) {
+        return perfilRemote.filtrarPerfiles(nombre, estado);
+    }
+
+    @GET
     @Path("/buscarPorEstado")
     @Operation(summary = "Buscar perfiles por estado", description = "Obtiene una lista de perfiles que coinciden con el estado especificado", tags = { "Perfiles" })
     @ApiResponses(value = {

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/ws/TipoEquipoResource.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/ws/TipoEquipoResource.java
@@ -103,6 +103,16 @@ public class TipoEquipoResource {
     }
 
     @GET
+    @Path("/filtrar")
+    @Operation(summary = "Filtrar tipos de equipo", description = "Filtra tipos de equipo por nombre y/o estado", tags = { "Tipos de Equipos" })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Lista filtrada correctamente", content = @Content(schema = @Schema(implementation = TiposEquipoDto.class)))
+    })
+    public List<TiposEquipoDto> filtrar(@QueryParam("nombre") String nombre, @QueryParam("estado") String estado) {
+        return this.er.filtrarTiposEquipo(nombre, estado);
+    }
+
+    @GET
     @Path("/seleccionar")
     @Operation(summary = "Buscar un tipo de equipo por ID", description = "Obtiene la información de un tipo de equipo específico por su ID", tags = { "Tipos de Equipos" })
     @ApiResponses(value = {

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/ws/TipoIntervencionesResource.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/ws/TipoIntervencionesResource.java
@@ -73,6 +73,16 @@ public class TipoIntervencionesResource {
     }
 
     @GET
+    @Path("/filtrar")
+    @Operation(summary = "Filtrar tipos de intervenciones", description = "Filtra tipos de intervenciones por nombre y/o estado", tags = { "Tipos de Intervenciones" })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Lista filtrada correctamente", content = @Content(schema = @Schema(implementation = TiposIntervencioneDto.class)))
+    })
+    public List<TiposIntervencioneDto> filtrar(@QueryParam("nombre") String nombre, @QueryParam("estado") String estado) {
+        return this.er.filtrarTiposIntervenciones(nombre, estado);
+    }
+
+    @GET
     @Path("/seleccionar")
     @Operation(summary = "Buscar un tipo de intervención por ID", description = "Obtiene la información de un tipo de intervención específico por su ID", tags = { "Tipos de Intervenciones" })
     @ApiResponses(value = {

--- a/frontend/src/components/Paginas/Perfiles/Listar.tsx
+++ b/frontend/src/components/Paginas/Perfiles/Listar.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import fetcher from "@/components/Helpers/Fetcher";
 import DynamicTable, { Column } from "@/components/Helpers/DynamicTable";
 import { Perfil } from "@/types/Usuario";
@@ -8,30 +8,6 @@ import { Perfil } from "@/types/Usuario";
 const Listar: React.FC = () => {
   const [perfiles, setPerfiles] = useState<Perfil[]>([]);
   const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
-
-  // Callback para búsqueda (filtros) desde DynamicTable
-  const handleSearch = async (filters: Record<string, string>) => {
-    setLoading(true);
-    try {
-      const params = new URLSearchParams();
-      Object.entries(filters).forEach(([key, value]) => {
-        if (value) params.append(key, value);
-      });
-      const queryString = params.toString() ? `?${params.toString()}` : "";
-      const data = await fetcher<Perfil[]>(`/perfiles/listar${queryString}`, { method: "GET" });
-      setPerfiles(data);
-    } catch (err: any) {
-      setError(err.message);
-    }
-    setLoading(false);
-  };
-
-  useEffect(() => {
-    // Cargar datos sin filtros al montar el componente
-    handleSearch({});
-  }, []);
-
   const columns: Column<Perfil>[] = [
     { header: "Nombre de Perfil", accessor: "nombrePerfil", type: "text", filterable: true },
     { header: "Estado", accessor: "estado", type: "text", filterable: true },
@@ -41,14 +17,12 @@ const Listar: React.FC = () => {
     
       <>
       {error && <p style={{ color: "red" }}>Error: {error}</p>}
-      {loading ? (
-        <p>Cargando...</p>
-      ) : (
-        <DynamicTable
+      <DynamicTable
           columns={columns}
           data={perfiles}
           withFilters={true}
-          onSearch={handleSearch}
+          filterUrl="/perfiles/filtrar"
+          onDataUpdate={setPerfiles}
           withActions={true}
           deleteUrl="/perfiles/inactivar"
           basePath="/perfiles"
@@ -58,8 +32,7 @@ const Listar: React.FC = () => {
               method: "PUT",
             });
           }}
-        />
-      )}
+      />
     </>
   );
 };

--- a/frontend/src/components/Paginas/TipoEquipos/Listar.tsx
+++ b/frontend/src/components/Paginas/TipoEquipos/Listar.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import fetcher from "@/components/Helpers/Fetcher";
 import DynamicTable, { Column } from "@/components/Helpers/DynamicTable";
 
@@ -12,27 +12,13 @@ interface TipoEquipo {
 const ListarTiposEquipos: React.FC = () => {
   const [tipos, setTipos] = useState<TipoEquipo[]>([]);
   const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
 
   // Estados para el modal de inactivación
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [tipoAEliminar, setTipoAEliminar] = useState<TipoEquipo | null>(null);
   const [loadingDelete, setLoadingDelete] = useState(false);
 
-  const handleSearch = async (filters: Record<string, string>) => {
-    setLoading(true);
-    try {
-      const data = await fetcher<TipoEquipo[]>("/tipoEquipos/listar", { method: "GET" });
-      setTipos(data);
-    } catch (err: any) {
-      setError(err.message);
-    }
-    setLoading(false);
-  };
 
-  useEffect(() => {
-    handleSearch({});
-  }, []);
 
   const columns: Column<TipoEquipo>[] = [
     { header: "ID", accessor: "id", type: "number", filterable: false },
@@ -69,7 +55,8 @@ const ListarTiposEquipos: React.FC = () => {
       });
       setShowDeleteModal(false);
       (window as any).__resolveDelete({ message: "Tipo de equipo inactivado correctamente" });
-      handleSearch({}); // Refresh list
+      const refreshed = await fetcher<TipoEquipo[]>("/tipoEquipos/filtrar", { method: "GET" });
+      setTipos(refreshed);
     } catch (err: any) {
       (window as any).__rejectDelete({ message: err.message || "Error al inactivar" });
     }
@@ -79,20 +66,17 @@ const ListarTiposEquipos: React.FC = () => {
   return (
     <>
       {error && <p style={{ color: "red" }}>Error: {error}</p>}
-      {loading ? (
-        <p>Cargando...</p>
-      ) : (
-        <DynamicTable
+      <DynamicTable
           columns={columns}
           data={tipos}
           withFilters={true}
-          onSearch={handleSearch}
+          filterUrl="/tipoEquipos/filtrar"
+          onDataUpdate={setTipos}
           withActions={true}
           deleteUrl="/tipoEquipos/inactivar"
           basePath="/tipoEquipos"
           onDelete={handleDeleteWithModal}
         />
-      )}
       {/* Modal de inactivación */}
       {showDeleteModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40">

--- a/frontend/src/components/Paginas/TipoEquipos/ListarBajas.tsx
+++ b/frontend/src/components/Paginas/TipoEquipos/ListarBajas.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import fetcher from "@/components/Helpers/Fetcher";
 import DynamicTable, { Column } from "@/components/Helpers/DynamicTable";
 
@@ -12,22 +12,7 @@ interface TipoEquipo {
 const ListarBajasTiposEquipos: React.FC = () => {
   const [tipos, setTipos] = useState<TipoEquipo[]>([]);
   const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
 
-  const handleSearch = async (filters: Record<string, string>) => {
-    setLoading(true);
-    try {
-      const data = await fetcher<TipoEquipo[]>("/tipoEquipos/listar", { method: "GET" });
-      setTipos(data.filter(t => t.estado !== "ACTIVO"));
-    } catch (err: any) {
-      setError(err.message);
-    }
-    setLoading(false);
-  };
-
-  useEffect(() => {
-    handleSearch({});
-  }, []);
 
   const columns: Column<TipoEquipo>[] = [
     { header: "ID", accessor: "id", type: "number", filterable: false },
@@ -50,17 +35,15 @@ const ListarBajasTiposEquipos: React.FC = () => {
     <>
       <h2 className="text-xl font-bold mb-4">Tipos de equipos inactivos</h2>
       {error && <p style={{ color: "red" }}>Error: {error}</p>}
-      {loading ? (
-        <p>Cargando...</p>
-      ) : (
-        <DynamicTable
+      <DynamicTable
           columns={columns}
           data={tipos}
           withFilters={true}
-          onSearch={handleSearch}
+          filterUrl="/tipoEquipos/filtrar"
+          initialFilters={{ estado: "INACTIVO" }}
+          onDataUpdate={setTipos}
           withActions={false}
         />
-      )}
     </>
   );
 };

--- a/frontend/src/components/Paginas/TiposIntervenciones/Listar.tsx
+++ b/frontend/src/components/Paginas/TiposIntervenciones/Listar.tsx
@@ -1,6 +1,7 @@
 "use client";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import fetcher from "@/components/Helpers/Fetcher";
+import DynamicTable, { Column } from "@/components/Helpers/DynamicTable";
 
 interface TipoIntervencion {
   id: number;
@@ -10,134 +11,38 @@ interface TipoIntervencion {
 
 const ListarTiposIntervenciones: React.FC = () => {
   const [tiposIntervenciones, setTiposIntervenciones] = useState<TipoIntervencion[]>([]);
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
 
-  const handleSearch = async (filters: Record<string, string>) => {
-    setLoading(true);
-    try {
-      const data = await fetcher<TipoIntervencion[]>("/tipoIntervenciones/listar", { method: "GET" });
-      setTiposIntervenciones(data);
-    } catch (err: any) {
-      setError(err.message);
-    }
-    setLoading(false);
-  };
-
-  const handleInactivar = async (id: number) => {
-    if (!confirm("¿Está seguro que desea inactivar este tipo de intervención?")) {
-      return;
-    }
-
-    try {
-      await fetcher(`/tipoIntervenciones/inactivar?id=${id}`, { method: "DELETE" });
-      
-      // Recargar la lista
-      await handleSearch({});
-      
-      alert("Tipo de intervención inactivado correctamente");
-    } catch (err: any) {
-      alert("Error al inactivar: " + err.message);
-    }
-  };
-
-  useEffect(() => {
-    handleSearch({});
-  }, []);
-
-
+  const columns: Column<TipoIntervencion>[] = [
+    { header: "ID", accessor: "id", type: "number", filterable: false },
+    { header: "Nombre del Tipo", accessor: "nombreTipo", type: "text", filterable: true },
+    { header: "Estado", accessor: "estado", type: "text", filterable: true }
+  ];
 
   return (
-    <div className="rounded-sm border border-stroke bg-white shadow-default dark:border-strokedark dark:bg-boxdark">
-      <div className="px-4 py-6 md:px-6 xl:px-7.5 flex justify-between items-center">
-        <h4 className="text-xl font-semibold text-black dark:text-white">
-          Tipos de Intervenciones
-        </h4>
+    <>
+      <div className="flex justify-between items-center mb-4">
+        <h4 className="text-xl font-semibold">Tipos de Intervenciones</h4>
         <button
-          onClick={() => window.location.href = '/tipoIntervenciones/crear'}
+          onClick={() => (window.location.href = "/tipoIntervenciones/crear")}
           className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-center font-medium text-white hover:bg-opacity-90"
         >
           Crear Nuevo Tipo
         </button>
       </div>
-
-      {error && (
-        <div className="mx-4 mb-4 p-4 bg-red-100 text-red-700 rounded-lg">
-          Error: {error}
-        </div>
-      )}
-
-      <div className="p-4 md:p-6 xl:p-7.5">
-        {loading ? (
-          <div className="flex justify-center items-center h-32">
-            <div className="text-gray-600">Cargando...</div>
-          </div>
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full table-auto">
-              <thead>
-                <tr className="bg-gray-2 text-left dark:bg-meta-4">
-                  <th className="min-w-[80px] px-4 py-4 font-medium text-black dark:text-white">
-                    ID
-                  </th>
-                  <th className="min-w-[220px] px-4 py-4 font-medium text-black dark:text-white">
-                    Nombre del Tipo
-                  </th>
-                  <th className="min-w-[120px] px-4 py-4 font-medium text-black dark:text-white">
-                    Estado
-                  </th>
-                  <th className="min-w-[120px] px-4 py-4 font-medium text-black dark:text-white">
-                    Acciones
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {tiposIntervenciones.map((tipo, key) => (
-                  <tr key={key}>
-                    <td className="border-b border-[#eee] px-4 py-5 dark:border-strokedark">
-                      <p className="text-black dark:text-white">
-                        {tipo.id}
-                      </p>
-                    </td>
-                    <td className="border-b border-[#eee] px-4 py-5 dark:border-strokedark">
-                      <p className="text-black dark:text-white">
-                        {tipo.nombreTipo}
-                      </p>
-                    </td>
-                    <td className="border-b border-[#eee] px-4 py-5 dark:border-strokedark">
-                      <p className={`inline-flex rounded-full px-3 py-1 text-sm font-medium ${
-                        tipo.estado === "ACTIVO" 
-                          ? "bg-success bg-opacity-10 text-success"
-                          : "bg-danger bg-opacity-10 text-danger"
-                      }`}>
-                        {tipo.estado}
-                      </p>
-                    </td>
-                    <td className="border-b border-[#eee] px-4 py-5 dark:border-strokedark">
-                      <div className="flex items-center space-x-3.5">
-                        {tipo.estado === "ACTIVO" && (
-                          <button
-                            onClick={() => handleInactivar(tipo.id)}
-                            className="inline-flex items-center justify-center rounded-md bg-red-600 px-3 py-1 text-center text-sm font-medium text-white hover:bg-opacity-90"
-                            title="Inactivar tipo de intervención"
-                          >
-                            Inactivar
-                          </button>
-                        )}
-                        {tipo.estado === "INACTIVO" && (
-                          <span className="text-sm text-gray-500">Ya inactivo</span>
-                        )}
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </div>
-    </div>
+      <DynamicTable
+        columns={columns}
+        data={tiposIntervenciones}
+        withFilters={true}
+        filterUrl="/tipoIntervenciones/filtrar"
+        onDataUpdate={setTiposIntervenciones}
+        withActions={true}
+        deleteUrl="/tipoIntervenciones/inactivar"
+        basePath="/tipoIntervenciones"
+        confirmDeleteMessage="¿Está seguro que desea inactivar este tipo de intervención?"
+        sendOnlyId={true}
+      />
+    </>
   );
 };
 
-export default ListarTiposIntervenciones; 
+export default ListarTiposIntervenciones;


### PR DESCRIPTION
## Summary
- enable filtering of `Perfil`, `TipoEquipo` and `TipoIntervencion` entities
- expose new `/filtrar` endpoints in REST resources
- switch front-end lists to use the new endpoints via `filterUrl`

## Testing
- `npm run lint` *(fails: next not found)*
- `mvn -q test` *(fails: unable to download jacoco plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68834db1ebd08324a41f4fbf81eef6dc