### PR TITLE
Fix resource test parameter counts

### DIFF
--- a/backend/src/test/java/codigocreativo/uy/servidorapp/ws/EquipoResourceTest.java
+++ b/backend/src/test/java/codigocreativo/uy/servidorapp/ws/EquipoResourceTest.java
@@ -243,7 +243,7 @@ class EquipoResourceTest {
         List<EquipoDto> equipos = List.of(new EquipoDto(), new EquipoDto());
         when(equipoRemote.obtenerEquiposFiltrado(any(Map.class))).thenReturn(equipos);
 
-        List<EquipoDto> result = equipoResource.filtrar("nombre", "tipo", "marca", "modelo", "12345", "Uruguay", "ProveedorX", "2022-01-01", "001", "sala");
+        List<EquipoDto> result = equipoResource.filtrar("nombre", "tipo", "marca", "modelo", "12345", null, "Uruguay", "ProveedorX", "2022-01-01", "001", "sala");
 
         assertNotNull(result);
         assertEquals(2, result.size());

--- a/backend/src/test/java/codigocreativo/uy/servidorapp/ws/UsuarioResourceTest.java
+++ b/backend/src/test/java/codigocreativo/uy/servidorapp/ws/UsuarioResourceTest.java
@@ -474,7 +474,7 @@ class UsuarioResourceTest {
         List<UsuarioDto> expectedList = Arrays.asList(null, null);
         when(usuarioRemote.obtenerUsuariosFiltrado(anyMap())).thenReturn(expectedList);
 
-        Response response = usuarioResource.filtrarUsuarios("John", "Doe", null, null, null, null);
+        Response response = usuarioResource.filtrarUsuarios("John", "Doe", null, null, null, null, null, null, null);
 
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         assertEquals(expectedList, response.getEntity());
@@ -486,7 +486,7 @@ class UsuarioResourceTest {
         List<UsuarioDto> expectedList = Arrays.asList(null, null);
         when(usuarioRemote.obtenerUsuariosFiltrado(anyMap())).thenReturn(expectedList);
 
-        Response response = usuarioResource.filtrarUsuarios("John", "Doe", "johndoe", "john@example.com", "Usuario", "ACTIVO");
+        Response response = usuarioResource.filtrarUsuarios("John", "Doe", "johndoe", "john@example.com", null, "Usuario", null, null, "ACTIVO");
 
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         assertEquals(expectedList, response.getEntity());
@@ -498,7 +498,7 @@ class UsuarioResourceTest {
         List<UsuarioDto> expectedList = Arrays.asList(null, null);
         when(usuarioRemote.obtenerUsuariosFiltrado(anyMap())).thenReturn(expectedList);
 
-        Response response = usuarioResource.filtrarUsuarios(null, null, null, null, null, null);
+        Response response = usuarioResource.filtrarUsuarios(null, null, null, null, null, null, null, null, null);
 
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         assertEquals(expectedList, response.getEntity());
@@ -510,7 +510,7 @@ class UsuarioResourceTest {
         List<UsuarioDto> expectedList = Arrays.asList(null, null);
         when(usuarioRemote.obtenerUsuariosFiltrado(anyMap())).thenReturn(expectedList);
 
-        Response response = usuarioResource.filtrarUsuarios(null, null, null, null, "default", null);
+        Response response = usuarioResource.filtrarUsuarios(null, null, null, null, null, null, null, "default", null);
 
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         assertEquals(expectedList, response.getEntity());


### PR DESCRIPTION
## Summary
- adjust EquipoResourceTest to include `estado` filter argument
- update UsuarioResourceTest calls to pass nine parameters

## Testing
- `mvn clean install` *(fails: could not resolve jacoco-maven-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_688360f677708324accf63ba062823bf