### PR TITLE
Fix listing regressions

### DIFF
--- a/frontend/src/components/Paginas/Funcionalidades/Listar.tsx
+++ b/frontend/src/components/Paginas/Funcionalidades/Listar.tsx
@@ -1,5 +1,6 @@
 "use client";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
+import fetcher from "@/components/Helpers/Fetcher";
 import DynamicTable, { Column } from "@/components/Helpers/DynamicTable";
 
 interface Perfil {
@@ -18,35 +19,60 @@ interface Funcionalidad {
 
 const ListarFuncionalidades: React.FC = () => {
   const [funcionalidades, setFuncionalidades] = useState<Funcionalidad[]>([]);
-  const [error] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  // Callback para búsqueda (filtros) desde DynamicTable
+  const handleSearch = async (filters: Record<string, string>) => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams();
+      Object.entries(filters).forEach(([key, value]) => {
+        if (value) params.append(key, value);
+      });
+      const queryString = params.toString() ? `?${params.toString()}` : "";
+      const data = await fetcher<Funcionalidad[]>(`/funcionalidades/listar${queryString}`, { method: "GET" });
+      setFuncionalidades(data);
+    } catch (err: any) {
+      setError(err.message);
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    // Cargar datos sin filtros al montar el componente
+    handleSearch({});
+  }, []);
 
   const columns: Column<Funcionalidad>[] = [
-    { header: "Nombre", accessor: "nombreFuncionalidad", type: "text", filterable: true, filterKey: "nombre" },
+    { header: "Nombre", accessor: "nombreFuncionalidad", type: "text", filterable: true },
     { header: "Ruta", accessor: "ruta", type: "text", filterable: false },
-    { header: "Estado", accessor: "estado", type: "text", filterable: true, filterKey: "estado" },
+    { header: "Estado", accessor: "estado", type: "text", filterable: true },
     {
       header: "Perfiles",
       accessor: (row) => row.perfiles.map(p => p.nombrePerfil).join(", "),
       type: "text",
-      filterable: true,
-      filterKey: "perfil"
+      filterable: true
     }
   ];
 
   return (
     <>
       {error && <p style={{ color: "red" }}>Error: {error}</p>}
-      <DynamicTable
-        columns={columns}
-        data={funcionalidades}
-        withFilters={true}
-        filterUrl="/funcionalidades/filtrar"
-        onDataUpdate={setFuncionalidades}
-        withActions={true}
-        deleteUrl="/funcionalidades/eliminar"
-        basePath="/funcionalidades"
-        sendOnlyId={false}
-      />
+      {loading ? (
+        <p>Cargando...</p>
+      ) : (
+        <DynamicTable
+          columns={columns}
+          data={funcionalidades}
+          withFilters={true}
+          onSearch={handleSearch}
+          withActions={true}
+          deleteUrl="/funcionalidades/eliminar"
+          basePath="/funcionalidades"
+          sendOnlyId={false}
+        />
+      )}
     </>
   );
 };

--- a/frontend/src/components/Paginas/Modelos/Listar.tsx
+++ b/frontend/src/components/Paginas/Modelos/Listar.tsx
@@ -1,5 +1,6 @@
 "use client";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
+import fetcher from "@/components/Helpers/Fetcher";
 import DynamicTable, { Column } from "@/components/Helpers/DynamicTable";
 
 interface Modelo {
@@ -15,32 +16,80 @@ interface Modelo {
 
 const ListarModelos: React.FC = () => {
   const [modelos, setModelos] = useState<Modelo[]>([]);
+  const [allModelos, setAllModelos] = useState<Modelo[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  // Función para cargar todos los modelos
+  const loadModelos = async () => {
+    setLoading(true);
+    try {
+      const data = await fetcher("/modelo/listar");
+      setAllModelos(data);
+      setModelos(data.filter((modelo: Modelo) => modelo.estado === "ACTIVO"));
+      setError(null);
+    } catch (err) {
+      setError("Error al cargar los modelos");
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Función para manejar búsqueda local
+  const handleSearch = (filters: any) => {
+    let filteredData = allModelos;
+
+    // Filtrar por estado
+    if (filters.estado) {
+      filteredData = filteredData.filter((modelo: Modelo) =>
+        modelo.estado.toLowerCase().includes(filters.estado.toLowerCase())
+      );
+    }
+
+    // Filtrar por nombre
+    if (filters.nombre) {
+      filteredData = filteredData.filter((modelo: Modelo) =>
+        modelo.nombre.toLowerCase().includes(filters.nombre.toLowerCase())
+      );
+    }
+
+    setModelos(filteredData);
+  };
+
+  useEffect(() => {
+    loadModelos();
+  }, []);
 
   const columns: Column<Modelo>[] = [
-    { header: "Nombre", accessor: "nombre", type: "text", filterable: true, filterKey: "nombre" },
+    { header: "Nombre", accessor: "nombre", type: "text", filterable: true },
     { header: "Marca", accessor: (row) => row.idMarca?.nombre || "-", type: "text", filterable: false },
-    { header: "Estado", accessor: "estado", type: "text", filterable: true, filterKey: "estado" },
+    { header: "Estado", accessor: "estado", type: "text", filterable: true },
   ];
 
   return (
     <>
       <h2 className="text-xl font-bold mb-4">Modelos</h2>
       {error && <p style={{ color: "red" }}>Error: {error}</p>}
-      <DynamicTable
-        columns={columns}
-        data={modelos}
-        withFilters={true}
-        filterUrl="/modelo/filtrar"
-        onDataUpdate={setModelos}
-        withActions={true}
-        deleteUrl="/modelo/inactivar"
-        basePath="/modelo"
-        initialFilters={{ estado: "ACTIVO" }}
-        sendOnlyId={true}
-      />
+      {loading ? (
+        <p>Cargando...</p>
+      ) : (
+        <DynamicTable
+          columns={columns}
+          data={modelos}
+          withFilters={true}
+          onSearch={handleSearch}
+          onDataUpdate={setModelos}
+          withActions={true}
+          deleteUrl="/modelo/inactivar"
+          basePath="/modelo"
+          initialFilters={{ estado: "ACTIVO" }}
+          sendOnlyId={true}
+          onReload={loadModelos}
+        />
+      )}
     </>
   );
 };
 
-export default ListarModelos; 
+export default ListarModelos;

--- a/frontend/src/components/Paginas/Usuarios/Listar.tsx
+++ b/frontend/src/components/Paginas/Usuarios/Listar.tsx
@@ -59,17 +59,10 @@ const ListarUsuarios: React.FC = () => {
     { header: "Nombre de Usuario", accessor: "nombreUsuario", type: "text", filterable: true },
     { header: "Email", accessor: "email", type: "email", filterable: true },
     {
-      header: "Módulo",
-      accessor: () => "",
-      type: "text",
-      filterable: true,
-      filterKey: "modulo",
-    },
-    {
       header: "Rol",
       accessor: (row: Usuario) => row.idPerfil?.nombrePerfil || "",
       type: "dropdown",
-      options: perfiles.map(perfil => ({ 
+      options: perfiles.map(perfil => ({
         value: perfil.nombrePerfil, 
         label: perfil.nombrePerfil 
       })), 


### PR DESCRIPTION
## Summary
- restore previous logic for listing functionalidad and modelos
- drop unused "Módulo" column from usuarios table

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6883655e7174832489bfadbc54447cec