### PR TITLE
Add filter endpoints and integrate with frontend

### DIFF
--- a/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/FuncionalidadBean.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/FuncionalidadBean.java
@@ -109,4 +109,31 @@ public class FuncionalidadBean implements FuncionalidadRemote {
         Funcionalidad funcionalidad = em.find(Funcionalidad.class, id);
         return funcionalidadMapper.toDto(funcionalidad, new CycleAvoidingMappingContext());
     }
+
+    @Override
+    public List<FuncionalidadDto> filtrarFuncionalidades(String nombre, String estado) {
+        Estados estadoEnum = null;
+        if (estado != null && !estado.trim().isEmpty()) {
+            estadoEnum = Estados.valueOf(estado);
+        }
+
+        StringBuilder jpql = new StringBuilder("SELECT f FROM Funcionalidad f WHERE 1=1");
+        if (nombre != null && !nombre.trim().isEmpty()) {
+            jpql.append(" AND UPPER(f.nombreFuncionalidad) LIKE UPPER(:nombre)");
+        }
+        if (estadoEnum != null) {
+            jpql.append(" AND f.estado = :estado");
+        }
+        jpql.append(" ORDER BY f.nombreFuncionalidad ASC");
+
+        var query = em.createQuery(jpql.toString(), Funcionalidad.class);
+        if (nombre != null && !nombre.trim().isEmpty()) {
+            query.setParameter("nombre", "%" + nombre.trim() + "%");
+        }
+        if (estadoEnum != null) {
+            query.setParameter("estado", estadoEnum.name());
+        }
+
+        return funcionalidadMapper.toDto(query.getResultList(), new CycleAvoidingMappingContext());
+    }
 }

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/FuncionalidadRemote.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/FuncionalidadRemote.java
@@ -20,4 +20,13 @@ public interface FuncionalidadRemote {
 
     FuncionalidadDto buscarPorId(Long id);
 
+    /**
+     * Filtra las funcionalidades por nombre y/o estado.
+     *
+     * @param nombre nombre de la funcionalidad
+     * @param estado estado de la funcionalidad (ACTIVO, INACTIVO, ...)
+     * @return lista filtrada
+     */
+    List<FuncionalidadDto> filtrarFuncionalidades(String nombre, String estado);
+
 }

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/ModelosEquipoBean.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/ModelosEquipoBean.java
@@ -132,6 +132,33 @@ public class ModelosEquipoBean implements ModelosEquipoRemote {
     }
 
     @Override
+    public List<ModelosEquipoDto> filtrarModelos(String nombre, String estado) {
+        Estados estadoEnum = null;
+        if (estado != null && !estado.trim().isEmpty()) {
+            estadoEnum = Estados.valueOf(estado);
+        }
+
+        StringBuilder jpql = new StringBuilder("SELECT m FROM ModelosEquipo m WHERE 1=1");
+        if (nombre != null && !nombre.trim().isEmpty()) {
+            jpql.append(" AND UPPER(m.nombre) LIKE UPPER(:nombre)");
+        }
+        if (estadoEnum != null) {
+            jpql.append(" AND m.estado = :estado");
+        }
+        jpql.append(" ORDER BY m.nombre ASC");
+
+        var query = em.createQuery(jpql.toString(), ModelosEquipo.class);
+        if (nombre != null && !nombre.trim().isEmpty()) {
+            query.setParameter("nombre", "%" + nombre.trim() + "%");
+        }
+        if (estadoEnum != null) {
+            query.setParameter("estado", estadoEnum.name());
+        }
+
+        return modelosEquipoMapper.toDto(query.getResultList());
+    }
+
+    @Override
     public void eliminarModelos(Long id) throws ServiciosException {
         if (id == null) {
             throw new ServiciosException("El ID es obligatorio");

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/ModelosEquipoRemote.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/ModelosEquipoRemote.java
@@ -13,4 +13,12 @@ public interface ModelosEquipoRemote {
     ModelosEquipoDto obtenerModelos(Long id) throws ServiciosException;
     List<ModelosEquipoDto> listarModelos();
     void eliminarModelos(Long id) throws ServiciosException;
+    /**
+     * Filtra los modelos por nombre y/o estado.
+     *
+     * @param nombre nombre del modelo, puede ser parcial
+     * @param estado estado del modelo (ACTIVO, INACTIVO, ...)
+     * @return lista de modelos que cumplen con el filtro
+     */
+    List<ModelosEquipoDto> filtrarModelos(String nombre, String estado);
 }

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/ws/FuncionalidadResource.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/ws/FuncionalidadResource.java
@@ -107,6 +107,22 @@ public class FuncionalidadResource {
     }
 
     @GET
+    @Path("/filtrar")
+    @Operation(summary = "Filtrar funcionalidades", description = "Filtra funcionalidades por nombre y/o estado", tags = { "Funcionalidades" })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Lista filtrada correctamente", content = @Content(schema = @Schema(implementation = FuncionalidadDto.class)))
+    })
+    public Response filtrar(@QueryParam("nombre") String nombre, @QueryParam("estado") String estado) {
+        try {
+            return Response.ok(this.funcionalidadRemote.filtrarFuncionalidades(nombre, estado)).build();
+        } catch (Exception e) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(java.util.Map.of("error", e.getMessage()))
+                    .build();
+        }
+    }
+
+    @GET
     @Path("/seleccionar/{id}")
     @Operation(summary = "Buscar una funcionalidad por ID", description = "Obtiene la información de una funcionalidad específica por su ID", tags = { "Funcionalidades" })
     @ApiResponses(value = {

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/ws/ModeloResource.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/ws/ModeloResource.java
@@ -102,6 +102,20 @@ public class ModeloResource {
     }
 
     @GET
+    @Path("/filtrar")
+    @Operation(summary = "Filtrar modelos", description = "Filtra modelos por nombre y/o estado", tags = { "Modelos" })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Lista filtrada correctamente", content = @Content(schema = @Schema(implementation = ModelosEquipoDto.class)))
+    })
+    public Response filtrar(@QueryParam("nombre") String nombre, @QueryParam("estado") String estado) {
+        try {
+            return Response.ok(this.er.filtrarModelos(nombre, estado)).build();
+        } catch (Exception e) {
+            return Response.status(400).entity(java.util.Map.of(ERROR, e.getMessage())).build();
+        }
+    }
+
+    @GET
     @Path("/seleccionar")
     @Operation(summary = "Buscar un modelo por ID", description = "Obtiene la información de un modelo específico por su ID", tags = { "Modelos" })
     @ApiResponses(value = {

--- a/backend/src/test/java/codigocreativo/uy/servidorapp/ws/FuncionalidadResourceTest.java
+++ b/backend/src/test/java/codigocreativo/uy/servidorapp/ws/FuncionalidadResourceTest.java
@@ -202,4 +202,16 @@ class FuncionalidadResourceTest {
         assertTrue(responseBody.contains("El ID de la funcionalidad es obligatorio para la eliminación"));
         verify(funcionalidadRemote, never()).eliminar(anyLong());
     }
+
+    @Test
+    void testFiltrarFuncionalidades() {
+        List<FuncionalidadDto> expected = List.of(new FuncionalidadDto());
+        when(funcionalidadRemote.filtrarFuncionalidades("Test", "ACTIVO")).thenReturn(expected);
+
+        Response response = funcionalidadResource.filtrar("Test", "ACTIVO");
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        assertEquals(expected, response.getEntity());
+        verify(funcionalidadRemote, times(1)).filtrarFuncionalidades("Test", "ACTIVO");
+    }
 }

--- a/backend/src/test/java/codigocreativo/uy/servidorapp/ws/ModeloResourceTest.java
+++ b/backend/src/test/java/codigocreativo/uy/servidorapp/ws/ModeloResourceTest.java
@@ -158,6 +158,18 @@ class ModeloResourceTest {
         verify(er, times(1)).listarModelos();
     }
 
+    @Test
+    void testFiltrarModelos() {
+        List<ModelosEquipoDto> expectedList = List.of(modeloDto);
+        when(er.filtrarModelos("Test", "ACTIVO")).thenReturn(expectedList);
+
+        Response response = modeloResource.filtrar("Test", "ACTIVO");
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        assertEquals(expectedList, response.getEntity());
+        verify(er, times(1)).filtrarModelos("Test", "ACTIVO");
+    }
+
     // ========== TESTS PARA BUSCAR POR ID ==========
 
     @Test

--- a/frontend/src/components/Paginas/Funcionalidades/Listar.tsx
+++ b/frontend/src/components/Paginas/Funcionalidades/Listar.tsx
@@ -22,26 +22,18 @@ const ListarFuncionalidades: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-  // Callback para búsqueda (filtros) desde DynamicTable
-  const handleSearch = async (filters: Record<string, string>) => {
-    setLoading(true);
-    try {
-      const params = new URLSearchParams();
-      Object.entries(filters).forEach(([key, value]) => {
-        if (value) params.append(key, value);
-      });
-      const queryString = params.toString() ? `?${params.toString()}` : "";
-      const data = await fetcher<Funcionalidad[]>(`/funcionalidades/listar${queryString}`, { method: "GET" });
-      setFuncionalidades(data);
-    } catch (err: any) {
-      setError(err.message);
-    }
-    setLoading(false);
-  };
-
   useEffect(() => {
-    // Cargar datos sin filtros al montar el componente
-    handleSearch({});
+    const loadData = async () => {
+      setLoading(true);
+      try {
+        const data = await fetcher<Funcionalidad[]>("/funcionalidades/filtrar", { method: "GET" });
+        setFuncionalidades(data);
+      } catch (err: any) {
+        setError(err.message);
+      }
+      setLoading(false);
+    };
+    loadData();
   }, []);
 
   const columns: Column<Funcionalidad>[] = [
@@ -66,7 +58,8 @@ const ListarFuncionalidades: React.FC = () => {
           columns={columns}
           data={funcionalidades}
           withFilters={true}
-          onSearch={handleSearch}
+          filterUrl="/funcionalidades/filtrar"
+          onDataUpdate={setFuncionalidades}
           withActions={true}
           deleteUrl="/funcionalidades/eliminar"
           basePath="/funcionalidades"

--- a/frontend/src/components/Paginas/Modelos/Listar.tsx
+++ b/frontend/src/components/Paginas/Modelos/Listar.tsx
@@ -16,49 +16,23 @@ interface Modelo {
 
 const ListarModelos: React.FC = () => {
   const [modelos, setModelos] = useState<Modelo[]>([]);
-  const [allModelos, setAllModelos] = useState<Modelo[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-  // Función para cargar todos los modelos
-  const loadModelos = async () => {
-    setLoading(true);
-    try {
-      const data = await fetcher("/modelo/listar");
-      setAllModelos(data);
-      setModelos(data.filter((modelo: Modelo) => modelo.estado === "ACTIVO"));
-      setError(null);
-    } catch (err) {
-      setError("Error al cargar los modelos");
-      console.error(err);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  // Función para manejar búsqueda local
-  const handleSearch = (filters: any) => {
-    let filteredData = allModelos;
-
-    // Filtrar por estado
-    if (filters.estado) {
-      filteredData = filteredData.filter((modelo: Modelo) =>
-        modelo.estado.toLowerCase().includes(filters.estado.toLowerCase())
-      );
-    }
-
-    // Filtrar por nombre
-    if (filters.nombre) {
-      filteredData = filteredData.filter((modelo: Modelo) =>
-        modelo.nombre.toLowerCase().includes(filters.nombre.toLowerCase())
-      );
-    }
-
-    setModelos(filteredData);
-  };
-
   useEffect(() => {
-    loadModelos();
+    const load = async () => {
+      setLoading(true);
+      try {
+        const data = await fetcher<Modelo[]>("/modelo/filtrar", { method: "GET" });
+        setModelos(data);
+      } catch (err) {
+        setError("Error al cargar los modelos");
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
   }, []);
 
   const columns: Column<Modelo>[] = [
@@ -78,14 +52,13 @@ const ListarModelos: React.FC = () => {
           columns={columns}
           data={modelos}
           withFilters={true}
-          onSearch={handleSearch}
+          filterUrl="/modelo/filtrar"
           onDataUpdate={setModelos}
           withActions={true}
           deleteUrl="/modelo/inactivar"
           basePath="/modelo"
           initialFilters={{ estado: "ACTIVO" }}
           sendOnlyId={true}
-          onReload={loadModelos}
         />
       )}
     </>


### PR DESCRIPTION
## Summary
- implement `filtrarFuncionalidades` and `filtrarModelos` service methods
- expose new `/filtrar` endpoints in `FuncionalidadResource` and `ModeloResource`
- update remote interfaces accordingly
- add tests for new endpoints
- hook frontend pages for `Modelos` and `Funcionalidades` to use filter endpoints

## Testing
- `mvn test` *(fails: Plugin org.jacoco:jacoco-maven-plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6883690dcc30832496ca9e51e82b7ce7