### PR TITLE
Implement consistent filter endpoints and connect front

### DIFF
--- a/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/ModelosEquipoBean.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/ModelosEquipoBean.java
@@ -189,4 +189,52 @@ public class ModelosEquipoBean implements ModelosEquipoRemote {
             // El nombre no existe, es válido
         }
     }
+
+    public List<ModelosEquipoDto> filtrarModelos(String estado, String nombre) {
+        Estados estadoEnum = null;
+        if (estado != null && !estado.trim().isEmpty()) {
+            estadoEnum = Estados.valueOf(estado);
+        }
+
+        boolean tieneEstado = estadoEnum != null;
+        boolean tieneNombre = nombre != null && !nombre.trim().isEmpty();
+
+        if (tieneEstado && tieneNombre) {
+            return obtenerModelosPorEstadoYNombre(estadoEnum, nombre.trim());
+        } else if (tieneEstado) {
+            return obtenerModelosPorEstado(estadoEnum);
+        } else if (tieneNombre) {
+            return obtenerModelosPorNombre(nombre.trim());
+        } else {
+            return listarModelos();
+        }
+    }
+
+    private List<ModelosEquipoDto> obtenerModelosPorEstado(Estados estado) {
+        List<ModelosEquipo> modelos = em.createQuery(
+                "SELECT m FROM ModelosEquipo m WHERE m.estado = :estado ORDER BY m.nombre ASC",
+                ModelosEquipo.class)
+                .setParameter("estado", estado.name())
+                .getResultList();
+        return modelosEquipoMapper.toDto(modelos);
+    }
+
+    private List<ModelosEquipoDto> obtenerModelosPorNombre(String nombre) {
+        List<ModelosEquipo> modelos = em.createQuery(
+                "SELECT m FROM ModelosEquipo m WHERE UPPER(m.nombre) LIKE UPPER(:nombre) ORDER BY m.nombre ASC",
+                ModelosEquipo.class)
+                .setParameter("nombre", "%" + nombre + "%")
+                .getResultList();
+        return modelosEquipoMapper.toDto(modelos);
+    }
+
+    private List<ModelosEquipoDto> obtenerModelosPorEstadoYNombre(Estados estado, String nombre) {
+        List<ModelosEquipo> modelos = em.createQuery(
+                "SELECT m FROM ModelosEquipo m WHERE m.estado = :estado AND UPPER(m.nombre) LIKE UPPER(:nombre) ORDER BY m.nombre ASC",
+                ModelosEquipo.class)
+                .setParameter("estado", estado.name())
+                .setParameter("nombre", "%" + nombre + "%")
+                .getResultList();
+        return modelosEquipoMapper.toDto(modelos);
+    }
 }

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/ModelosEquipoRemote.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/ModelosEquipoRemote.java
@@ -13,4 +13,5 @@ public interface ModelosEquipoRemote {
     ModelosEquipoDto obtenerModelos(Long id) throws ServiciosException;
     List<ModelosEquipoDto> listarModelos();
     void eliminarModelos(Long id) throws ServiciosException;
+    List<ModelosEquipoDto> filtrarModelos(String estado, String nombre);
 }

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/PerfilBean.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/PerfilBean.java
@@ -159,5 +159,32 @@ public class PerfilBean implements PerfilRemote {
                 .getResultList());
     }
 
+    public List<PerfilDto> filtrarPerfiles(String estado, String nombre) {
+        Estados estadoEnum = null;
+        if (estado != null && !estado.trim().isEmpty()) {
+            estadoEnum = Estados.valueOf(estado);
+        }
+
+        boolean tieneEstado = estadoEnum != null;
+        boolean tieneNombre = nombre != null && !nombre.trim().isEmpty();
+
+        if (tieneEstado && tieneNombre) {
+            return listarPerfilesPorEstadoYNombre(estadoEnum, nombre.trim());
+        } else if (tieneEstado) {
+            return listarPerfilesPorEstado(estadoEnum);
+        } else if (tieneNombre) {
+            return listarPerfilesPorNombre(nombre.trim());
+        } else {
+            return obtenerPerfiles();
+        }
+    }
+
+    private List<PerfilDto> listarPerfilesPorEstadoYNombre(Estados estado, String nombre) {
+        return perfilMapper.toDtoList(em.createQuery("SELECT p FROM Perfil p WHERE p.estado = :estado AND UPPER(p.nombrePerfil) LIKE UPPER(:nombre)", Perfil.class)
+                .setParameter("estado", estado)
+                .setParameter("nombre", "%" + nombre + "%")
+                .getResultList());
+    }
+
     
 }

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/PerfilRemote.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/PerfilRemote.java
@@ -16,5 +16,6 @@ public interface PerfilRemote {
     public List<PerfilDto> obtenerPerfiles();
     public List<PerfilDto> listarPerfilesPorNombre(String nombre);
     public List<PerfilDto> listarPerfilesPorEstado(Estados estado);
+    List<PerfilDto> filtrarPerfiles(String estado, String nombre);
 
 }

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/TipoIntervencioneBean.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/TipoIntervencioneBean.java
@@ -52,4 +52,46 @@ public class TipoIntervencioneBean implements TipoIntervencioneRemote {
                 .setParameter("id", id)
                 .executeUpdate();
     }
+
+    public List<TiposIntervencioneDto> filtrarTiposIntervenciones(String estado, String nombre) {
+        codigocreativo.uy.servidorapp.enumerados.Estados estadoEnum = null;
+        if (estado != null && !estado.trim().isEmpty()) {
+            estadoEnum = codigocreativo.uy.servidorapp.enumerados.Estados.valueOf(estado);
+        }
+
+        boolean tieneEstado = estadoEnum != null;
+        boolean tieneNombre = nombre != null && !nombre.trim().isEmpty();
+
+        if (tieneEstado && tieneNombre) {
+            return obtenerPorEstadoYNombre(estadoEnum, nombre.trim());
+        } else if (tieneEstado) {
+            return obtenerPorEstado(estadoEnum);
+        } else if (tieneNombre) {
+            return obtenerPorNombre(nombre.trim());
+        } else {
+            return obtenerTiposIntervenciones();
+        }
+    }
+
+    private List<TiposIntervencioneDto> obtenerPorEstado(codigocreativo.uy.servidorapp.enumerados.Estados estado) {
+        List<TiposIntervencione> tipos = em.createQuery("SELECT t FROM TiposIntervencione t WHERE t.estado = :estado ORDER BY t.nombreTipo ASC", TiposIntervencione.class)
+                .setParameter("estado", estado.name())
+                .getResultList();
+        return tiposIntervencioneMapper.toDto(tipos);
+    }
+
+    private List<TiposIntervencioneDto> obtenerPorNombre(String nombre) {
+        List<TiposIntervencione> tipos = em.createQuery("SELECT t FROM TiposIntervencione t WHERE UPPER(t.nombreTipo) LIKE UPPER(:nombre) ORDER BY t.nombreTipo ASC", TiposIntervencione.class)
+                .setParameter("nombre", "%" + nombre + "%")
+                .getResultList();
+        return tiposIntervencioneMapper.toDto(tipos);
+    }
+
+    private List<TiposIntervencioneDto> obtenerPorEstadoYNombre(codigocreativo.uy.servidorapp.enumerados.Estados estado, String nombre) {
+        List<TiposIntervencione> tipos = em.createQuery("SELECT t FROM TiposIntervencione t WHERE t.estado = :estado AND UPPER(t.nombreTipo) LIKE UPPER(:nombre) ORDER BY t.nombreTipo ASC", TiposIntervencione.class)
+                .setParameter("estado", estado.name())
+                .setParameter("nombre", "%" + nombre + "%")
+                .getResultList();
+        return tiposIntervencioneMapper.toDto(tipos);
+    }
 }

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/TipoIntervencioneRemote.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/TipoIntervencioneRemote.java
@@ -12,4 +12,5 @@ public interface TipoIntervencioneRemote {
     void crearTipoIntervencion(TiposIntervencioneDto tipoIntervencion);
     void modificarTipoIntervencion(TiposIntervencioneDto tipoIntervencion);
     void eliminarTipoIntervencion(Long id);
+    List<TiposIntervencioneDto> filtrarTiposIntervenciones(String estado, String nombre);
 }

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/TiposEquipoBean.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/TiposEquipoBean.java
@@ -126,6 +126,48 @@ public class TiposEquipoBean implements TiposEquipoRemote{
         List<TiposEquipo> tiposEquipos = em.createQuery("SELECT t FROM TiposEquipo t ORDER BY t.nombreTipo ASC", TiposEquipo.class).getResultList();
         return tiposEquipoMapper.toDto(tiposEquipos);
     }
+
+    public List<TiposEquipoDto> filtrarTiposEquipos(String estado, String nombre) {
+        Estados estadoEnum = null;
+        if (estado != null && !estado.trim().isEmpty()) {
+            estadoEnum = Estados.valueOf(estado);
+        }
+
+        boolean tieneEstado = estadoEnum != null;
+        boolean tieneNombre = nombre != null && !nombre.trim().isEmpty();
+
+        if (tieneEstado && tieneNombre) {
+            return obtenerPorEstadoYNombre(estadoEnum, nombre.trim());
+        } else if (tieneEstado) {
+            return obtenerPorEstado(estadoEnum);
+        } else if (tieneNombre) {
+            return obtenerPorNombre(nombre.trim());
+        } else {
+            return listarTiposEquipo();
+        }
+    }
+
+    private List<TiposEquipoDto> obtenerPorEstado(Estados estado) {
+        List<TiposEquipo> tipos = em.createQuery("SELECT t FROM TiposEquipo t WHERE t.estado = :estado ORDER BY t.nombreTipo ASC", TiposEquipo.class)
+                .setParameter("estado", estado.name())
+                .getResultList();
+        return tiposEquipoMapper.toDto(tipos);
+    }
+
+    private List<TiposEquipoDto> obtenerPorNombre(String nombre) {
+        List<TiposEquipo> tipos = em.createQuery("SELECT t FROM TiposEquipo t WHERE UPPER(t.nombreTipo) LIKE UPPER(:nombre) ORDER BY t.nombreTipo ASC", TiposEquipo.class)
+                .setParameter("nombre", "%" + nombre + "%")
+                .getResultList();
+        return tiposEquipoMapper.toDto(tipos);
+    }
+
+    private List<TiposEquipoDto> obtenerPorEstadoYNombre(Estados estado, String nombre) {
+        List<TiposEquipo> tipos = em.createQuery("SELECT t FROM TiposEquipo t WHERE t.estado = :estado AND UPPER(t.nombreTipo) LIKE UPPER(:nombre) ORDER BY t.nombreTipo ASC", TiposEquipo.class)
+                .setParameter("estado", estado.name())
+                .setParameter("nombre", "%" + nombre + "%")
+                .getResultList();
+        return tiposEquipoMapper.toDto(tipos);
+    }
     
     /**
      * Valida que el nombre del tipo de equipo sea único en la base de datos

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/TiposEquipoRemote.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/TiposEquipoRemote.java
@@ -13,4 +13,5 @@ public interface TiposEquipoRemote {
     public void eliminarTiposEquipo(Long id) throws ServiciosException;
     public TiposEquipoDto obtenerPorId(Long id) throws ServiciosException;
     public List<TiposEquipoDto> listarTiposEquipo();
+    List<TiposEquipoDto> filtrarTiposEquipos(String estado, String nombre);
 }

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/ws/ModeloResource.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/ws/ModeloResource.java
@@ -119,4 +119,19 @@ public class ModeloResource {
                 .build();
         }
     }
+
+    @GET
+    @Path("/filtrar")
+    @Operation(summary = "Filtrar modelos por estado y/o nombre", description = "Obtiene una lista de modelos filtrados por estado y/o nombre", tags = { "Modelos" })
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Lista de modelos filtrada correctamente"),
+        @ApiResponse(responseCode = "400", description = "Estado inválido", content = @Content(schema = @Schema(example = "{\"error\": \"Estado inválido\"}")))
+    })
+    public Response filtrarModelos(@QueryParam("estado") String estado, @QueryParam("nombre") String nombre) {
+        try {
+            return Response.ok(er.filtrarModelos(estado, nombre)).build();
+        } catch (Exception e) {
+            return Response.status(400).entity(java.util.Map.of(ERROR, "Estado inválido: " + e.getMessage())).build();
+        }
+    }
 }

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/ws/PerfilResource.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/ws/PerfilResource.java
@@ -166,4 +166,21 @@ public class PerfilResource {
     public List<PerfilDto> listarPerfilesPorEstado(@Parameter(description = "Estado del perfil a buscar") @QueryParam("estado") Estados estado) {
         return perfilRemote.listarPerfilesPorEstado(estado);
     }
+
+    @GET
+    @Path("/filtrar")
+    @Operation(summary = "Filtrar perfiles por estado y/o nombre", description = "Obtiene una lista de perfiles filtrados", tags = { "Perfiles" })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Lista filtrada correctamente"),
+            @ApiResponse(responseCode = "400", description = "Estado inválido", content = @Content(schema = @Schema(example = "{\"error\": \"Estado inválido\"}")))
+    })
+    public Response filtrarPerfiles(@QueryParam("estado") String estado, @QueryParam("nombre") String nombre) {
+        try {
+            return Response.ok(perfilRemote.filtrarPerfiles(estado, nombre)).build();
+        } catch (Exception e) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(java.util.Map.of("error", "Estado inválido: " + e.getMessage()))
+                    .build();
+        }
+    }
 }

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/ws/TipoEquipoResource.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/ws/TipoEquipoResource.java
@@ -120,4 +120,19 @@ public class TipoEquipoResource {
                 .build();
         }
     }
+
+    @GET
+    @Path("/filtrar")
+    @Operation(summary = "Filtrar tipos de equipos por estado y/o nombre", description = "Obtiene una lista filtrada de tipos de equipos", tags = { "Tipos de Equipos" })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Lista filtrada correctamente"),
+            @ApiResponse(responseCode = "400", description = "Estado inválido", content = @Content(schema = @Schema(example = "{\"error\": \"Estado inválido\"}")))
+    })
+    public Response filtrarTiposEquipos(@QueryParam("estado") String estado, @QueryParam("nombre") String nombre) {
+        try {
+            return Response.ok(er.filtrarTiposEquipos(estado, nombre)).build();
+        } catch (Exception e) {
+            return Response.status(400).entity(Map.of(ERROR, "Estado inválido: " + e.getMessage())).build();
+        }
+    }
 }

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/ws/TipoIntervencionesResource.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/ws/TipoIntervencionesResource.java
@@ -82,4 +82,19 @@ public class TipoIntervencionesResource {
     public TiposIntervencioneDto buscarPorId(@Parameter(description = "ID del tipo de intervención a buscar", required = true) @QueryParam("id") Long id) {
         return this.er.obtenerTipoIntervencion(id);
     }
+
+    @GET
+    @Path("/filtrar")
+    @Operation(summary = "Filtrar tipos de intervención por estado y/o nombre", description = "Obtiene una lista filtrada de tipos de intervención", tags = { "Tipos de Intervenciones" })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Lista filtrada correctamente"),
+            @ApiResponse(responseCode = "400", description = "Estado inválido", content = @Content(schema = @Schema(example = "{\"error\": \"Estado inválido\"}")))
+    })
+    public Response filtrarTiposIntervenciones(@QueryParam("estado") String estado, @QueryParam("nombre") String nombre) {
+        try {
+            return Response.ok(er.filtrarTiposIntervenciones(estado, nombre)).build();
+        } catch (Exception e) {
+            return Response.status(400).entity(java.util.Map.of("error", "Estado inválido: " + e.getMessage())).build();
+        }
+    }
 }

--- a/frontend/src/components/Paginas/Modelos/Listar.tsx
+++ b/frontend/src/components/Paginas/Modelos/Listar.tsx
@@ -1,6 +1,5 @@
 "use client";
-import React, { useEffect, useState } from "react";
-import fetcher from "@/components/Helpers/Fetcher";
+import React, { useState } from "react";
 import DynamicTable, { Column } from "@/components/Helpers/DynamicTable";
 
 interface Modelo {
@@ -16,50 +15,8 @@ interface Modelo {
 
 const ListarModelos: React.FC = () => {
   const [modelos, setModelos] = useState<Modelo[]>([]);
-  const [allModelos, setAllModelos] = useState<Modelo[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
-
-  // Función para cargar todos los modelos
-  const loadModelos = async () => {
-    setLoading(true);
-    try {
-      const data = await fetcher("/modelo/listar");
-      setAllModelos(data);
-      setModelos(data.filter((modelo: Modelo) => modelo.estado === "ACTIVO"));
-      setError(null);
-    } catch (err) {
-      setError("Error al cargar los modelos");
-      console.error(err);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  // Función para manejar búsqueda local
-  const handleSearch = (filters: any) => {
-    let filteredData = allModelos;
-
-    // Filtrar por estado
-    if (filters.estado) {
-      filteredData = filteredData.filter((modelo: Modelo) => 
-        modelo.estado.toLowerCase().includes(filters.estado.toLowerCase())
-      );
-    }
-
-    // Filtrar por nombre
-    if (filters.nombre) {
-      filteredData = filteredData.filter((modelo: Modelo) => 
-        modelo.nombre.toLowerCase().includes(filters.nombre.toLowerCase())
-      );
-    }
-
-    setModelos(filteredData);
-  };
-
-  useEffect(() => {
-    loadModelos();
-  }, []);
 
   const columns: Column<Modelo>[] = [
     { header: "Nombre", accessor: "nombre", type: "text", filterable: true },
@@ -78,14 +35,13 @@ const ListarModelos: React.FC = () => {
           columns={columns}
           data={modelos}
           withFilters={true}
-          onSearch={handleSearch}
           onDataUpdate={setModelos}
           withActions={true}
           deleteUrl="/modelo/inactivar"
           basePath="/modelo"
+          filterUrl="/modelo/filtrar"
           initialFilters={{ estado: "ACTIVO" }}
           sendOnlyId={true}
-          onReload={loadModelos}
         />
       )}
     </>

--- a/frontend/src/components/Paginas/Perfiles/Listar.tsx
+++ b/frontend/src/components/Paginas/Perfiles/Listar.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import fetcher from "@/components/Helpers/Fetcher";
 import DynamicTable, { Column } from "@/components/Helpers/DynamicTable";
 import { Perfil } from "@/types/Usuario";
@@ -10,27 +10,9 @@ const Listar: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-  // Callback para búsqueda (filtros) desde DynamicTable
-  const handleSearch = async (filters: Record<string, string>) => {
-    setLoading(true);
-    try {
-      const params = new URLSearchParams();
-      Object.entries(filters).forEach(([key, value]) => {
-        if (value) params.append(key, value);
-      });
-      const queryString = params.toString() ? `?${params.toString()}` : "";
-      const data = await fetcher<Perfil[]>(`/perfiles/listar${queryString}`, { method: "GET" });
-      setPerfiles(data);
-    } catch (err: any) {
-      setError(err.message);
-    }
-    setLoading(false);
-  };
-
-  useEffect(() => {
-    // Cargar datos sin filtros al montar el componente
-    handleSearch({});
-  }, []);
+  const [perfiles, setPerfiles] = useState<Perfil[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
 
   const columns: Column<Perfil>[] = [
     { header: "Nombre de Perfil", accessor: "nombrePerfil", type: "text", filterable: true },
@@ -48,7 +30,7 @@ const Listar: React.FC = () => {
           columns={columns}
           data={perfiles}
           withFilters={true}
-          onSearch={handleSearch}
+          filterUrl="/perfiles/filtrar"
           withActions={true}
           deleteUrl="/perfiles/inactivar"
           basePath="/perfiles"

--- a/frontend/src/components/Paginas/TipoEquipos/Listar.tsx
+++ b/frontend/src/components/Paginas/TipoEquipos/Listar.tsx
@@ -1,7 +1,7 @@
 "use client";
-import React, { useEffect, useState } from "react";
-import fetcher from "@/components/Helpers/Fetcher";
+import React, { useState } from "react";
 import DynamicTable, { Column } from "@/components/Helpers/DynamicTable";
+import fetcher from "@/components/Helpers/Fetcher";
 
 interface TipoEquipo {
   id: number;
@@ -19,20 +19,7 @@ const ListarTiposEquipos: React.FC = () => {
   const [tipoAEliminar, setTipoAEliminar] = useState<TipoEquipo | null>(null);
   const [loadingDelete, setLoadingDelete] = useState(false);
 
-  const handleSearch = async (filters: Record<string, string>) => {
-    setLoading(true);
-    try {
-      const data = await fetcher<TipoEquipo[]>("/tipoEquipos/listar", { method: "GET" });
-      setTipos(data);
-    } catch (err: any) {
-      setError(err.message);
-    }
-    setLoading(false);
-  };
 
-  useEffect(() => {
-    handleSearch({});
-  }, []);
 
   const columns: Column<TipoEquipo>[] = [
     { header: "ID", accessor: "id", type: "number", filterable: false },
@@ -69,7 +56,8 @@ const ListarTiposEquipos: React.FC = () => {
       });
       setShowDeleteModal(false);
       (window as any).__resolveDelete({ message: "Tipo de equipo inactivado correctamente" });
-      handleSearch({}); // Refresh list
+      const data = await fetcher<TipoEquipo[]>("/tipoEquipos/filtrar?estado=ACTIVO", { method: "GET" });
+      setTipos(data);
     } catch (err: any) {
       (window as any).__rejectDelete({ message: err.message || "Error al inactivar" });
     }
@@ -86,10 +74,10 @@ const ListarTiposEquipos: React.FC = () => {
           columns={columns}
           data={tipos}
           withFilters={true}
-          onSearch={handleSearch}
           withActions={true}
           deleteUrl="/tipoEquipos/inactivar"
           basePath="/tipoEquipos"
+          filterUrl="/tipoEquipos/filtrar"
           onDelete={handleDeleteWithModal}
         />
       )}

--- a/frontend/src/components/Paginas/TiposIntervenciones/Listar.tsx
+++ b/frontend/src/components/Paginas/TiposIntervenciones/Listar.tsx
@@ -1,6 +1,6 @@
 "use client";
-import React, { useEffect, useState } from "react";
-import fetcher from "@/components/Helpers/Fetcher";
+import React, { useState } from "react";
+import DynamicTable, { Column } from "@/components/Helpers/DynamicTable";
 
 interface TipoIntervencion {
   id: number;
@@ -9,135 +9,30 @@ interface TipoIntervencion {
 }
 
 const ListarTiposIntervenciones: React.FC = () => {
-  const [tiposIntervenciones, setTiposIntervenciones] = useState<TipoIntervencion[]>([]);
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
+  const [tipos, setTipos] = useState<TipoIntervencion[]>([]);
 
-  const handleSearch = async (filters: Record<string, string>) => {
-    setLoading(true);
-    try {
-      const data = await fetcher<TipoIntervencion[]>("/tipoIntervenciones/listar", { method: "GET" });
-      setTiposIntervenciones(data);
-    } catch (err: any) {
-      setError(err.message);
-    }
-    setLoading(false);
-  };
-
-  const handleInactivar = async (id: number) => {
-    if (!confirm("¿Está seguro que desea inactivar este tipo de intervención?")) {
-      return;
-    }
-
-    try {
-      await fetcher(`/tipoIntervenciones/inactivar?id=${id}`, { method: "DELETE" });
-      
-      // Recargar la lista
-      await handleSearch({});
-      
-      alert("Tipo de intervención inactivado correctamente");
-    } catch (err: any) {
-      alert("Error al inactivar: " + err.message);
-    }
-  };
-
-  useEffect(() => {
-    handleSearch({});
-  }, []);
-
-
+  const columns: Column<TipoIntervencion>[] = [
+    { header: "Nombre del Tipo", accessor: "nombreTipo", type: "text", filterable: true },
+    { header: "Estado", accessor: "estado", type: "text", filterable: true },
+  ];
 
   return (
-    <div className="rounded-sm border border-stroke bg-white shadow-default dark:border-strokedark dark:bg-boxdark">
-      <div className="px-4 py-6 md:px-6 xl:px-7.5 flex justify-between items-center">
-        <h4 className="text-xl font-semibold text-black dark:text-white">
-          Tipos de Intervenciones
-        </h4>
-        <button
-          onClick={() => window.location.href = '/tipoIntervenciones/crear'}
-          className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-center font-medium text-white hover:bg-opacity-90"
-        >
-          Crear Nuevo Tipo
-        </button>
-      </div>
-
-      {error && (
-        <div className="mx-4 mb-4 p-4 bg-red-100 text-red-700 rounded-lg">
-          Error: {error}
-        </div>
-      )}
-
-      <div className="p-4 md:p-6 xl:p-7.5">
-        {loading ? (
-          <div className="flex justify-center items-center h-32">
-            <div className="text-gray-600">Cargando...</div>
-          </div>
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full table-auto">
-              <thead>
-                <tr className="bg-gray-2 text-left dark:bg-meta-4">
-                  <th className="min-w-[80px] px-4 py-4 font-medium text-black dark:text-white">
-                    ID
-                  </th>
-                  <th className="min-w-[220px] px-4 py-4 font-medium text-black dark:text-white">
-                    Nombre del Tipo
-                  </th>
-                  <th className="min-w-[120px] px-4 py-4 font-medium text-black dark:text-white">
-                    Estado
-                  </th>
-                  <th className="min-w-[120px] px-4 py-4 font-medium text-black dark:text-white">
-                    Acciones
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {tiposIntervenciones.map((tipo, key) => (
-                  <tr key={key}>
-                    <td className="border-b border-[#eee] px-4 py-5 dark:border-strokedark">
-                      <p className="text-black dark:text-white">
-                        {tipo.id}
-                      </p>
-                    </td>
-                    <td className="border-b border-[#eee] px-4 py-5 dark:border-strokedark">
-                      <p className="text-black dark:text-white">
-                        {tipo.nombreTipo}
-                      </p>
-                    </td>
-                    <td className="border-b border-[#eee] px-4 py-5 dark:border-strokedark">
-                      <p className={`inline-flex rounded-full px-3 py-1 text-sm font-medium ${
-                        tipo.estado === "ACTIVO" 
-                          ? "bg-success bg-opacity-10 text-success"
-                          : "bg-danger bg-opacity-10 text-danger"
-                      }`}>
-                        {tipo.estado}
-                      </p>
-                    </td>
-                    <td className="border-b border-[#eee] px-4 py-5 dark:border-strokedark">
-                      <div className="flex items-center space-x-3.5">
-                        {tipo.estado === "ACTIVO" && (
-                          <button
-                            onClick={() => handleInactivar(tipo.id)}
-                            className="inline-flex items-center justify-center rounded-md bg-red-600 px-3 py-1 text-center text-sm font-medium text-white hover:bg-opacity-90"
-                            title="Inactivar tipo de intervención"
-                          >
-                            Inactivar
-                          </button>
-                        )}
-                        {tipo.estado === "INACTIVO" && (
-                          <span className="text-sm text-gray-500">Ya inactivo</span>
-                        )}
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </div>
-    </div>
+    <>
+      <h4 className="text-xl font-semibold mb-4">Tipos de Intervenciones</h4>
+      <DynamicTable
+        columns={columns}
+        data={tipos}
+        withFilters={true}
+        filterUrl="/tipoIntervenciones/filtrar"
+        withActions={true}
+        deleteUrl="/tipoIntervenciones/inactivar"
+        basePath="/tipoIntervenciones"
+        onDataUpdate={setTipos}
+        initialFilters={{ estado: "ACTIVO" }}
+        sendOnlyId={true}
+      />
+    </>
   );
 };
 
-export default ListarTiposIntervenciones; 
+export default ListarTiposIntervenciones;


### PR DESCRIPTION
## Summary
- add filter methods to remote interfaces and beans
- expose `/filtrar` endpoints for models, types of equipment, profiles and types of intervention
- connect dynamic tables in front-end pages to new filter endpoints
- simplify client-side filtering in pages

## Testing
- `mvn test` *(fails: Plugin resolution requires network)*

------
https://chatgpt.com/codex/tasks/task_e_68837765743c83248e3bc215997c1438