### PR TITLE
Fix text on cancel buttons

### DIFF
--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -671,7 +671,7 @@ const Settings = () => {
                         setSuccess(null);
                       }}
                     >
-                      Cancelar
+                      Volver
                     </button>
                     <button
                       className="flex justify-center rounded bg-primary px-6 py-2 font-medium text-gray hover:bg-opacity-90 disabled:opacity-50"
@@ -738,7 +738,7 @@ const Settings = () => {
                 className="flex justify-center rounded border border-stroke px-6 py-2 font-medium text-black hover:shadow-1 dark:border-strokedark dark:text-white"
                 onClick={() => setShowConfirmModal(false)}
               >
-                Cancelar
+                Volver
               </button>
               <button
                 className="flex justify-center rounded bg-primary px-6 py-2 font-medium text-gray hover:bg-opacity-90 disabled:opacity-50"

--- a/frontend/src/components/DynamicTable.tsx
+++ b/frontend/src/components/DynamicTable.tsx
@@ -419,7 +419,7 @@ const DynamicTable: React.FC<TableProps> = ({
                   onClick={() => setShowModal(false)}
                   disabled={loadingDelete}
                 >
-                  Cancelar
+                  Volver
                 </button>
               </div>
             </div>

--- a/frontend/src/components/Equipos/Baja/borrarEquipo.tsx
+++ b/frontend/src/components/Equipos/Baja/borrarEquipo.tsx
@@ -233,7 +233,7 @@ const DeleteEquipo = () => {
                 onClick={() => setShowConfirmModal(false)}
                 className='bg-violet-800 text-white p-2 rounded'
               >
-                Cancelar
+                Volver
               </button>
             </div>
           </div>

--- a/frontend/src/components/Equipos/agregarEquipo.tsx
+++ b/frontend/src/components/Equipos/agregarEquipo.tsx
@@ -364,7 +364,7 @@ const EquiposCreate = () => {
                     onClick={() => setShowConfirmModal(false)}
                     className='bg-violet-800 text-white p-2 rounded'
                   >
-                    Cancelar
+                    Volver
                   </button>
                 </div>
               </div>

--- a/frontend/src/components/Funcionalidades.tsx
+++ b/frontend/src/components/Funcionalidades.tsx
@@ -83,7 +83,7 @@ const FuncionalidadesList: React.FC<FuncionalidadesListProps> = (params) => {
                                 onClick={() => setShowConfirmModal(false)}
                                 className='bg-violet-800 text-white p-2 rounded'
                             >
-                                Cancelar
+                                Volver
                             </button>
                         </div>
                     </div>

--- a/frontend/src/components/Funcionalidades/editarFuncionalidad.tsx
+++ b/frontend/src/components/Funcionalidades/editarFuncionalidad.tsx
@@ -127,7 +127,7 @@ const EditFuncionalidad = () => {
               onClick={() => router.push('/funcionalidades')}
               className='px-4 py-2 ml-2 text-white bg-neutral-500 rounded hover:bg-neutral-700'
           >
-            Cancelar
+            Volver
           </button>
         </form>
       </div>

--- a/frontend/src/components/Helpers/CreateDynamic.tsx
+++ b/frontend/src/components/Helpers/CreateDynamic.tsx
@@ -273,7 +273,7 @@ const CreateDynamic: React.FC<Props> = ({ fields, createUrl, successMessage, err
             <h3 className="text-lg font-bold mb-4">¿Desea crear este registro?</h3>
             <p className="mb-6">Confirme que los datos ingresados son correctos para crear el registro.</p>
             <div className="flex justify-end gap-4">
-              <button onClick={() => setShowConfirm(false)} className="px-4 py-2 rounded bg-gray-300 hover:bg-gray-400 dark:bg-meta-4 dark:hover:bg-meta-3">Cancelar</button>
+              <button onClick={() => setShowConfirm(false)} className="px-4 py-2 rounded bg-gray-300 hover:bg-gray-400 dark:bg-meta-4 dark:hover:bg-meta-3">Volver</button>
               <button onClick={handleConfirm} className="px-4 py-2 rounded bg-primary text-white hover:bg-opacity-90">Confirmar</button>
             </div>
           </div>

--- a/frontend/src/components/Helpers/DynamicTable.tsx
+++ b/frontend/src/components/Helpers/DynamicTable.tsx
@@ -789,7 +789,7 @@ function DynamicTable<T extends { id: number }>({
                 onClick={() => setShowConfirmDeleteModal(false)}
                 className="px-4 py-2 bg-gray-300 text-gray-800 rounded hover:bg-gray-400"
               >
-                Cancelar
+                Volver
               </button>
               <button
                 onClick={async () => {

--- a/frontend/src/components/Helpers/EditDynamic.tsx
+++ b/frontend/src/components/Helpers/EditDynamic.tsx
@@ -364,7 +364,7 @@ function EditDynamic<T extends { id: number }>({
             onClick={() => router.push(backLink)}
             className="px-4 py-2 bg-gray-300 text-gray-800 rounded hover:bg-gray-400"
           >
-            Cancelar
+            Volver
           </button>
         </div>
       </form>
@@ -380,7 +380,7 @@ function EditDynamic<T extends { id: number }>({
                 onClick={() => setShowConfirmModal(false)}
                 className="px-4 py-2 bg-gray-300 text-gray-800 rounded hover:bg-gray-400"
               >
-                Cancelar
+                Volver
               </button>
               <button
                 onClick={handleConfirmSubmit}

--- a/frontend/src/components/Helpers/RegisterForm.tsx
+++ b/frontend/src/components/Helpers/RegisterForm.tsx
@@ -576,7 +576,7 @@ const RegisterForm: React.FC<RegisterFormProps> = ({ requiresAuth = false }) => 
                     </div>
                   </div>
                   <div className="flex justify-end gap-4">
-                    <button onClick={() => setShowConfirm(false)} className="px-4 py-2 rounded bg-gray-300 hover:bg-gray-400 dark:bg-meta-4 dark:hover:bg-meta-3">Cancelar</button>
+                    <button onClick={() => setShowConfirm(false)} className="px-4 py-2 rounded bg-gray-300 hover:bg-gray-400 dark:bg-meta-4 dark:hover:bg-meta-3">Volver</button>
                     <button onClick={handleConfirm} className="px-4 py-2 rounded bg-primary text-white hover:bg-opacity-90">Confirmar</button>
                   </div>
                 </div>

--- a/frontend/src/components/Paginas/Equipos/Crear.tsx
+++ b/frontend/src/components/Paginas/Equipos/Crear.tsx
@@ -361,7 +361,7 @@ const CrearEquipo: React.FC = () => {
             <h3 className="text-lg font-bold mb-4 text-yellow-600">Advertencia de garantía</h3>
             <p className="mb-6">La fecha de garantía ingresada ya está vencida. ¿Desea continuar?</p>
             <div className="flex justify-end gap-4">
-              <button onClick={() => setShowGarantiaWarning(false)} className="px-4 py-2 rounded bg-gray-300 hover:bg-gray-400 dark:bg-meta-4 dark:hover:bg-meta-3">Cancelar</button>
+              <button onClick={() => setShowGarantiaWarning(false)} className="px-4 py-2 rounded bg-gray-300 hover:bg-gray-400 dark:bg-meta-4 dark:hover:bg-meta-3">Volver</button>
               <button onClick={() => { setShowGarantiaWarning(false); setShowConfirm(true); }} className="px-4 py-2 rounded bg-primary text-white hover:bg-opacity-90">Continuar</button>
             </div>
           </div>
@@ -374,7 +374,7 @@ const CrearEquipo: React.FC = () => {
             <h3 className="text-lg font-bold mb-4">¿Desea crear este equipo?</h3>
             <p className="mb-6">Confirme que los datos ingresados son correctos para registrar el equipo.</p>
             <div className="flex justify-end gap-4">
-              <button onClick={() => setShowConfirm(false)} className="px-4 py-2 rounded bg-gray-300 hover:bg-gray-400 dark:bg-meta-4 dark:hover:bg-meta-3">Cancelar</button>
+              <button onClick={() => setShowConfirm(false)} className="px-4 py-2 rounded bg-gray-300 hover:bg-gray-400 dark:bg-meta-4 dark:hover:bg-meta-3">Volver</button>
               <button onClick={handleConfirm} className="px-4 py-2 rounded bg-primary text-white hover:bg-opacity-90">Confirmar</button>
             </div>
           </div>

--- a/frontend/src/components/Paginas/Equipos/Editar.tsx
+++ b/frontend/src/components/Paginas/Equipos/Editar.tsx
@@ -420,7 +420,7 @@ const EditarEquipo: React.FC = () => {
             onClick={() => window.history.back()}
             className="px-6 py-2 bg-gray-300 text-gray-800 rounded hover:bg-gray-400"
           >
-            Cancelar
+            Volver
           </button>
           <button
             type="submit"
@@ -451,7 +451,7 @@ const EditarEquipo: React.FC = () => {
                 onClick={() => setShowConfirm(false)}
                 className="px-4 py-2 bg-gray-300 text-gray-800 rounded hover:bg-gray-400"
               >
-                Cancelar
+                Volver
               </button>
               <button
                 onClick={handleConfirm}
@@ -476,7 +476,7 @@ const EditarEquipo: React.FC = () => {
                 onClick={() => setShowGarantiaWarning(false)}
                 className="px-4 py-2 bg-gray-300 text-gray-800 rounded hover:bg-gray-400"
               >
-                Cancelar
+                Volver
               </button>
               <button
                 onClick={() => {

--- a/frontend/src/components/Paginas/Equipos/Listar.tsx
+++ b/frontend/src/components/Paginas/Equipos/Listar.tsx
@@ -270,7 +270,7 @@ const ListarEquipos: React.FC = () => {
                 }}
                 className="px-4 py-2 rounded bg-gray-300 hover:bg-gray-400"
               >
-                Cancelar
+                Volver
               </button>
               <button
                 onClick={confirmarEliminacion}

--- a/frontend/src/components/Paginas/Intervenciones/Crear.tsx
+++ b/frontend/src/components/Paginas/Intervenciones/Crear.tsx
@@ -247,7 +247,7 @@ const CrearIntervencion: React.FC = () => {
               onClick={() => window.history.back()}
               className="flex justify-center rounded border border-stroke px-6 py-2 font-medium text-black hover:shadow-1 dark:border-strokedark dark:text-white"
             >
-              Cancelar
+              Volver
             </button>
             <button
               type="submit"
@@ -280,7 +280,7 @@ const CrearIntervencion: React.FC = () => {
                 onClick={() => setShowConfirm(false)}
                 className="px-4 py-2 rounded border border-stroke text-black hover:shadow-1 dark:border-strokedark dark:text-white"
               >
-                Cancelar
+                Volver
               </button>
               <button
                 onClick={handleConfirm}

--- a/frontend/src/components/Paginas/Intervenciones/Editar.tsx
+++ b/frontend/src/components/Paginas/Intervenciones/Editar.tsx
@@ -284,7 +284,7 @@ const EditarIntervencion: React.FC = () => {
               onClick={() => window.history.back()}
               className="flex justify-center rounded border border-stroke px-6 py-2 font-medium text-black hover:shadow-1 dark:border-strokedark dark:text-white"
             >
-              Cancelar
+              Volver
             </button>
             <button
               type="submit"
@@ -317,7 +317,7 @@ const EditarIntervencion: React.FC = () => {
                 onClick={() => setShowConfirm(false)}
                 className="px-4 py-2 rounded border border-stroke text-black hover:shadow-1 dark:border-strokedark dark:text-white"
               >
-                Cancelar
+                Volver
               </button>
               <button
                 onClick={handleConfirm}

--- a/frontend/src/components/Paginas/TipoEquipos/Crear.tsx
+++ b/frontend/src/components/Paginas/TipoEquipos/Crear.tsx
@@ -79,7 +79,7 @@ const CrearTipoEquipo: React.FC = () => {
             <h3 className="text-lg font-bold mb-4">¿Desea crear este tipo de equipo?</h3>
             <p className="mb-6">Confirme que los datos ingresados son correctos.</p>
             <div className="flex justify-end gap-4">
-              <button onClick={() => setShowConfirm(false)} className="px-4 py-2 rounded bg-gray-300 hover:bg-gray-400 dark:bg-meta-4 dark:hover:bg-meta-3">Cancelar</button>
+              <button onClick={() => setShowConfirm(false)} className="px-4 py-2 rounded bg-gray-300 hover:bg-gray-400 dark:bg-meta-4 dark:hover:bg-meta-3">Volver</button>
               <button onClick={handleConfirm} className="px-4 py-2 rounded bg-primary text-white hover:bg-opacity-90">Confirmar</button>
             </div>
           </div>

--- a/frontend/src/components/Paginas/TipoEquipos/Listar.tsx
+++ b/frontend/src/components/Paginas/TipoEquipos/Listar.tsx
@@ -123,7 +123,7 @@ const ListarTiposEquipos: React.FC = () => {
                 }}
                 className="px-4 py-2 rounded bg-gray-300 hover:bg-gray-400"
               >
-                Cancelar
+                Volver
               </button>
               <button
                 onClick={confirmarEliminacion}

--- a/frontend/src/components/Paginas/TiposIntervenciones/Crear.tsx
+++ b/frontend/src/components/Paginas/TiposIntervenciones/Crear.tsx
@@ -107,7 +107,7 @@ const CrearTipoIntervencion: React.FC = () => {
               onClick={() => window.history.back()}
               className="flex justify-center rounded border border-stroke px-6 py-2 font-medium text-black hover:shadow-1 dark:border-strokedark dark:text-white"
             >
-              Cancelar
+              Volver
             </button>
             <button
               type="submit"
@@ -137,7 +137,7 @@ const CrearTipoIntervencion: React.FC = () => {
                 onClick={() => setShowConfirm(false)}
                 className="px-4 py-2 rounded border border-stroke text-black hover:shadow-1 dark:border-strokedark dark:text-white"
               >
-                Cancelar
+                Volver
               </button>
               <button
                 onClick={handleConfirm}


### PR DESCRIPTION
## Summary
- change button text from **Cancelar** to **Volver** across the frontend

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6885f0ee954483249678423a780fa6a4