### PR TITLE
Add back navigation links

### DIFF
--- a/frontend/src/components/Helpers/CreateDynamic.tsx
+++ b/frontend/src/components/Helpers/CreateDynamic.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React, { useState, useEffect } from "react";
+import Link from "next/link";
 import fetcher from "@/components/Helpers/Fetcher";
 import flatpickr from "flatpickr";
 import "flatpickr/dist/flatpickr.min.css";
@@ -58,9 +59,21 @@ type Props = {
   successMessage?: string;
   errorMessage?: string;
   onSuccess?: (data: any) => void;
+  /**
+   * (Opcional) Ruta a la que se redirigirá cuando se haga clic en el botón
+   * "Volver al listado".
+   */
+  backLink?: string;
 };
 
-const CreateDynamic: React.FC<Props> = ({ fields, createUrl, successMessage, errorMessage, onSuccess }) => {
+const CreateDynamic: React.FC<Props> = ({
+  fields,
+  createUrl,
+  successMessage,
+  errorMessage,
+  onSuccess,
+  backLink,
+}) => {
   const [form, setForm] = useState<Record<string, any>>(() => {
     const initial: Record<string, any> = {};
     fields.forEach(f => {
@@ -265,6 +278,16 @@ const CreateDynamic: React.FC<Props> = ({ fields, createUrl, successMessage, err
             className="w-full cursor-pointer rounded-lg border border-primary bg-primary p-4 text-white transition hover:bg-opacity-90 disabled:opacity-60"
           />
         </div>
+        {backLink && (
+          <div className="mt-6 flex gap-4">
+            <Link
+              href={backLink}
+              className="inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+            >
+              Volver al listado
+            </Link>
+          </div>
+        )}
       </form>
       {/* Modal de confirmación */}
       {showConfirm && (

--- a/frontend/src/components/Paginas/Equipos/Crear.tsx
+++ b/frontend/src/components/Paginas/Equipos/Crear.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React, { useEffect, useState } from "react";
+import Link from "next/link";
 import fetcher from "@/components/Helpers/Fetcher";
 
 const IMGBB_API_KEY = process.env.NEXT_PUBLIC_IMGBB_API_KEY as string;
@@ -350,8 +351,19 @@ const CrearEquipo: React.FC = () => {
         </div>
         {error && <div className="mt-4 text-red-500">{error}</div>}
         {message && <div className="mt-4 text-green-600">{message}</div>}
-        <div className="mt-6 flex justify-end gap-4">
-          <input type="submit" value={loading ? "Creando..." : "Crear equipo"} disabled={loading} className="px-6 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 cursor-pointer disabled:opacity-60" />
+        <div className="mt-6 flex gap-4 justify-end">
+          <input
+            type="submit"
+            value={loading ? "Creando..." : "Crear equipo"}
+            disabled={loading}
+            className="px-6 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 cursor-pointer disabled:opacity-60"
+          />
+          <Link
+            href="/equipos"
+            className="inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+          >
+            Volver al listado
+          </Link>
         </div>
       </form>
       {/* Modal de advertencia de garantía vencida */}

--- a/frontend/src/components/Paginas/Funcionalidades/Editar.tsx
+++ b/frontend/src/components/Paginas/Funcionalidades/Editar.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
 import fetcher from "@/components/Helpers/Fetcher";
 
 interface PerfilDto {
@@ -154,12 +155,20 @@ const EditarFuncionalidad: React.FC = () => {
         </div>
         {error && <div className="mb-4 text-red-500">{error}</div>}
         {message && <div className="mb-4 text-green-600">{message}</div>}
-        <input
-          type="submit"
-          value={saving ? "Guardando..." : "Guardar cambios"}
-          disabled={saving}
-          className="w-full cursor-pointer rounded-lg border border-primary bg-primary p-4 text-white transition hover:bg-opacity-90 disabled:opacity-60"
-        />
+        <div className="flex gap-4 mt-4">
+          <input
+            type="submit"
+            value={saving ? "Guardando..." : "Guardar cambios"}
+            disabled={saving}
+            className="cursor-pointer rounded-lg border border-primary bg-primary p-4 text-white transition hover:bg-opacity-90 disabled:opacity-60"
+          />
+          <Link
+            href="/funcionalidades"
+            className="inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+          >
+            Volver al listado
+          </Link>
+        </div>
       </form>
     </div>
   );

--- a/frontend/src/components/Paginas/Marcas/Crear.tsx
+++ b/frontend/src/components/Paginas/Marcas/Crear.tsx
@@ -16,6 +16,7 @@ const CrearMarca: React.FC = () => {
     <CreateDynamic
       fields={fields}
       createUrl="/marca/crear"
+      backLink="/marca"
     />
   );
 };

--- a/frontend/src/components/Paginas/Modelos/Crear.tsx
+++ b/frontend/src/components/Paginas/Modelos/Crear.tsx
@@ -32,6 +32,7 @@ const CrearModelo: React.FC = () => {
     <CreateDynamic
       fields={fields}
       createUrl="/modelo/crear"
+      backLink="/modelo"
     />
   );
 };

--- a/frontend/src/components/Paginas/Paises/Crear.tsx
+++ b/frontend/src/components/Paginas/Paises/Crear.tsx
@@ -12,6 +12,7 @@ const CrearPais: React.FC = () => {
     <CreateDynamic
       fields={fields}
       createUrl="/paises/crear"
+      backLink="/paises"
     />
   );
 };

--- a/frontend/src/components/Paginas/Perfiles/Crear.tsx
+++ b/frontend/src/components/Paginas/Perfiles/Crear.tsx
@@ -9,6 +9,7 @@ const CrearPerfil = () => (
       { label: "Nombre del Perfil", accessor: "nombrePerfil", type: "text", required: true },
     ]}
     successMessage="Perfil creado exitosamente"
+    backLink="/perfiles"
   />
 );
 

--- a/frontend/src/components/Paginas/Proveedores/Crear.tsx
+++ b/frontend/src/components/Paginas/Proveedores/Crear.tsx
@@ -40,6 +40,7 @@ const CrearProveedor: React.FC = () => {
       createUrl="/proveedores/crear"
       fields={fields}
       successMessage="Proveedor creado exitosamente"
+      backLink="/proveedores"
     />
   );
 };

--- a/frontend/src/components/Paginas/Proveedores/Ver.tsx
+++ b/frontend/src/components/Paginas/Proveedores/Ver.tsx
@@ -61,6 +61,7 @@ const VerProveedor: React.FC = () => {
               <DetailView
                 data={proveedor}
                 columns={columns}
+                backLink="/proveedores"
               />
             </div>
           </div>

--- a/frontend/src/components/Paginas/TipoEquipos/Crear.tsx
+++ b/frontend/src/components/Paginas/TipoEquipos/Crear.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React, { useState } from "react";
+import Link from "next/link";
 import fetcher from "@/components/Helpers/Fetcher";
 
 const CrearTipoEquipo: React.FC = () => {
@@ -68,8 +69,19 @@ const CrearTipoEquipo: React.FC = () => {
         </div>
         {error && <div className="mt-4 text-red-500">{error}</div>}
         {message && <div className="mt-4 text-green-600">{message}</div>}
-        <div className="mt-6 flex justify-end gap-4">
-          <input type="submit" value={loading ? "Creando..." : "Crear tipo de equipo"} disabled={loading} className="px-6 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 cursor-pointer disabled:opacity-60" />
+        <div className="mt-6 flex gap-4 justify-end">
+          <input
+            type="submit"
+            value={loading ? "Creando..." : "Crear tipo de equipo"}
+            disabled={loading}
+            className="px-6 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 cursor-pointer disabled:opacity-60"
+          />
+          <Link
+            href="/tipoEquipos"
+            className="inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+          >
+            Volver al listado
+          </Link>
         </div>
       </form>
       {/* Modal de confirmación */}


### PR DESCRIPTION
## Summary
- allow CreateDynamic to accept an optional `backLink` and render a standard link
- apply back navigation to create pages for paises, marcas, modelos, perfiles, proveedores
- add back navigation in creation pages for equipo and tipo de equipo
- add back button to editar funcionalidad and ver proveedor

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6885f6b573088324b42a2099da20c391