### PR TITLE
Fix wording for deactivation messages

### DIFF
--- a/backend/Nueva carpeta/UsuarioResource.java
+++ b/backend/Nueva carpeta/UsuarioResource.java
@@ -169,7 +169,7 @@ public class UsuarioResource {
         }
 
         this.er.eliminarUsuario(usuarioAInactivar);
-        return Response.status(200).entity("{\"message\":\"Usuario inactivado correctamente\"}").build();
+        return Response.status(200).entity("{\"message\":\"Usuario desactivado correctamente\"}").build();
     }
 
     @GET

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/UsuarioBean.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/UsuarioBean.java
@@ -352,7 +352,7 @@ public class UsuarioBean implements UsuarioRemote {
 
 
     /**
-     * Valida que un usuario pueda ser inactivado por otro usuario
+     * Valida que un usuario pueda ser desactivado por otro usuario
      */
     public void validarInactivacionUsuario(String emailSolicitante, String cedulaUsuarioAInactivar) throws ServiciosException {
         // Obtener el usuario que solicita la inactivación

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/ws/EquipoResource.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/ws/EquipoResource.java
@@ -89,7 +89,7 @@ public class EquipoResource {
     @SecurityRequirement(name = "bearerAuth")
     @Operation(summary = "Inactivar un equipo", description = "Inactiva un equipo en la base de datos", tags = { "Equipos" })
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Equipo inactivado correctamente"),
+            @ApiResponse(responseCode = "200", description = "Equipo desactivado correctamente"),
             @ApiResponse(responseCode = "400", description = "Solicitud inválida - Campos obligatorios faltantes", content = @Content(schema = @Schema(implementation = String.class))),
             @ApiResponse(responseCode = "404", description = "Equipo no encontrado", content = @Content(schema = @Schema(implementation = String.class))),
             @ApiResponse(responseCode = "500", description = "Error interno del servidor", content = @Content(schema = @Schema(implementation = String.class)))

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/ws/MarcaResource.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/ws/MarcaResource.java
@@ -75,15 +75,15 @@ public class MarcaResource {
     @Path("/inactivar")
     @Operation(summary = "Inactivar una marca", description = "Inactiva una marca en la base de datos", tags = { "Marcas" })
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Marca inactivada correctamente",
-            content = @Content(schema = @Schema(example = "{\"message\": \"Marca inactivada correctamente\"}"))),
+        @ApiResponse(responseCode = "200", description = "Marca desactivada correctamente",
+            content = @Content(schema = @Schema(example = "{\"message\": \"Marca desactivada correctamente\"}"))),
         @ApiResponse(responseCode = "400", description = "Error al inactivar la marca",
             content = @Content(schema = @Schema(example = "{\"error\": \"Error al inactivar la marca\"}")))
     })
     public Response eliminarMarca(@Parameter(description = "ID de la marca a inactivar", required = true) @QueryParam("id") Long id) {
         try {
             this.er.eliminarMarca(id);
-            return Response.ok(Map.of(MESSAGE, "Marca inactivada correctamente")).build();
+            return Response.ok(Map.of(MESSAGE, "Marca desactivada correctamente")).build();
         } catch (Exception e) {
             return Response.status(400)
                 .entity(Map.of(ERROR, e.getMessage()))

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/ws/ModeloResource.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/ws/ModeloResource.java
@@ -75,15 +75,15 @@ public class ModeloResource {
     @Path("/inactivar")
     @Operation(summary = "Inactivar un modelo", description = "Inactiva un modelo en la base de datos", tags = { "Modelos" })
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Modelo inactivado correctamente", 
-                content = @Content(schema = @Schema(example = "{\"message\": \"Modelo inactivado correctamente\"}"))),
+            @ApiResponse(responseCode = "200", description = "Modelo desactivado correctamente",
+                content = @Content(schema = @Schema(example = "{\"message\": \"Modelo desactivado correctamente\"}"))),
             @ApiResponse(responseCode = "400", description = "Error al inactivar el modelo", 
                 content = @Content(schema = @Schema(example = "{\"error\": \"Error al inactivar el modelo\"}")))
     })
     public Response eliminarModelo(@Parameter(description = "ID del modelo a inactivar", required = true) @QueryParam("id") Long id) {
         try {
             this.er.eliminarModelos(id);
-            return Response.ok(java.util.Map.of(MESSAGE, "Modelo inactivado correctamente")).build();
+            return Response.ok(java.util.Map.of(MESSAGE, "Modelo desactivado correctamente")).build();
         } catch (Exception e) {
             return Response.status(400)
                 .entity(java.util.Map.of(ERROR, e.getMessage()))

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/ws/PaisesResource.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/ws/PaisesResource.java
@@ -98,13 +98,13 @@ public class PaisesResource {
     @Path("/inactivar")
     @Operation(summary = "Inactivar un país", description = "Inactiva un país en la base de datos", tags = { "Paises" })
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "País inactivado correctamente", content = @Content(schema = @Schema(example = "{\"message\": \"País inactivado correctamente\"}"))),
+        @ApiResponse(responseCode = "200", description = "País desactivado correctamente", content = @Content(schema = @Schema(example = "{\"message\": \"País desactivado correctamente\"}"))),
         @ApiResponse(responseCode = "404", description = "País no encontrado", content = @Content(schema = @Schema(example = "{\"error\": \"País no encontrado\"}")))
     })
     public Response inactivarPais(@QueryParam("id") Long id) {
         try {
             this.er.inactivarPais(id);
-            return Response.ok(java.util.Map.of("message", "País inactivado correctamente")).build();
+            return Response.ok(java.util.Map.of("message", "País desactivado correctamente")).build();
         } catch (Exception e) {
             return Response.status(404).entity(java.util.Map.of(ERROR, "País no encontrado: " + e.getMessage())).build();
         }

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/ws/PerfilResource.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/ws/PerfilResource.java
@@ -89,7 +89,7 @@ public class PerfilResource {
     @Path("/inactivar")
     @Operation(summary = "Inactivar un perfil", description = "Inactiva un perfil existente", tags = { "Perfiles" })
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Perfil inactivado correctamente"),
+            @ApiResponse(responseCode = "200", description = "Perfil desactivado correctamente"),
             @ApiResponse(responseCode = "400", description = "Solicitud inválida", content = @Content(schema = @Schema(implementation = String.class))),
             @ApiResponse(responseCode = "404", description = "Perfil no encontrado", content = @Content(schema = @Schema(implementation = String.class)))
     })
@@ -107,7 +107,7 @@ public class PerfilResource {
             if (perfil != null) {
                 perfilRemote.eliminarPerfil(perfil);
                 return Response.ok()
-                        .entity(String.format(MSG_JSON_FORMAT, "Perfil inactivado correctamente"))
+                        .entity(String.format(MSG_JSON_FORMAT, "Perfil desactivado correctamente"))
                         .build();
             } else {
                 return Response.status(Response.Status.NOT_FOUND)

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/ws/ProveedoresResource.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/ws/ProveedoresResource.java
@@ -66,13 +66,13 @@ public class ProveedoresResource {
     @Path("/inactivar")
     @Operation(summary = "Inactivar un proveedor", description = "Inactiva un proveedor en la base de datos", tags = { "Proveedores" })
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Proveedor inactivado correctamente", content = @Content(schema = @Schema(example = "{\"message\": \"Proveedor inactivado correctamente\"}"))),
+            @ApiResponse(responseCode = "200", description = "Proveedor desactivado correctamente", content = @Content(schema = @Schema(example = "{\"message\": \"Proveedor desactivado correctamente\"}"))),
             @ApiResponse(responseCode = "404", description = "Proveedor no encontrado", content = @Content(schema = @Schema(example = "{\"error\": \"Proveedor no encontrado\"}")))
     })
     public Response eliminarProveedor(@Parameter(description = "ID del proveedor a inactivar", required = true) @QueryParam("id") Long id) {
         try {
             this.er.eliminarProveedor(id);
-            return Response.ok(java.util.Map.of(MESSAGE, "Proveedor inactivado correctamente")).build();
+            return Response.ok(java.util.Map.of(MESSAGE, "Proveedor desactivado correctamente")).build();
         } catch (Exception e) {
             return Response.status(404).entity(java.util.Map.of(ERROR, e.getMessage())).build();
         }

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/ws/TipoEquipoResource.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/ws/TipoEquipoResource.java
@@ -76,15 +76,15 @@ public class TipoEquipoResource {
     @Path("/inactivar")
     @Operation(summary = "Inactivar un tipo de equipo", description = "Inactiva un tipo de equipo en la base de datos", tags = { "Tipos de Equipos" })
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Tipo de equipo inactivado correctamente", 
-                content = @Content(schema = @Schema(example = "{\"message\": \"Tipo de equipo inactivado correctamente\"}"))),
+            @ApiResponse(responseCode = "200", description = "Tipo de equipo desactivado correctamente",
+                content = @Content(schema = @Schema(example = "{\"message\": \"Tipo de equipo desactivado correctamente\"}"))),
             @ApiResponse(responseCode = "400", description = "Error al inactivar el tipo de equipo", 
                 content = @Content(schema = @Schema(example = "{\"error\": \"Error al inactivar el tipo de equipo\"}")))
     })
     public Response eliminar(@Parameter(description = "ID del tipo de equipo a inactivar", required = true) @QueryParam("id") Long id) {
         try {
             this.er.eliminarTiposEquipo(id);
-            return Response.ok(Map.of(MESSAGE, "Tipo de equipo inactivado correctamente")).build();
+            return Response.ok(Map.of(MESSAGE, "Tipo de equipo desactivado correctamente")).build();
         } catch (Exception e) {
             return Response.status(400)
                 .entity(Map.of(ERROR, e.getMessage()))

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/ws/TipoIntervencionesResource.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/ws/TipoIntervencionesResource.java
@@ -54,7 +54,7 @@ public class TipoIntervencionesResource {
     @Path("/inactivar")
     @Operation(summary = "Inactivar un tipo de intervención", description = "Inactiva un tipo de intervención en la base de datos", tags = { "Tipos de Intervenciones" })
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Tipo de intervención inactivado correctamente"),
+            @ApiResponse(responseCode = "200", description = "Tipo de intervención desactivado correctamente"),
             @ApiResponse(responseCode = "404", description = "Tipo de intervención no encontrado", content = @Content(schema = @Schema(implementation = String.class)))
     })
     public Response eliminar(@Parameter(description = "ID del tipo de intervención a inactivar", required = true) @QueryParam("id") Long id) {

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/ws/UsuarioResource.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/ws/UsuarioResource.java
@@ -244,7 +244,7 @@ public class UsuarioResource {
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200",
-                    description = "Usuario inactivado correctamente",
+                    description = "Usuario desactivado correctamente",
                     content = @Content(schema = @Schema(implementation = String.class))
             ),
             @ApiResponse(
@@ -313,7 +313,7 @@ public class UsuarioResource {
             }
 
             er.inactivarUsuario(emailSolicitante, usuarioAInactivar.getCedula());
-            return Response.status(200).entity("{\"message\":\"Usuario inactivado correctamente\"}").build();
+            return Response.status(200).entity("{\"message\":\"Usuario desactivado correctamente\"}").build();
         } catch (ServiciosException e) {
             if (e.getMessage().contains("No autorizado") || e.getMessage().contains("no tiene permisos")) {
                 return Response.status(Response.Status.FORBIDDEN)

--- a/backend/src/test/java/codigocreativo/uy/servidorapp/ws/MarcaResourceTest.java
+++ b/backend/src/test/java/codigocreativo/uy/servidorapp/ws/MarcaResourceTest.java
@@ -124,7 +124,7 @@ class MarcaResourceTest {
         
         @SuppressWarnings("unchecked")
         Map<String, String> responseBody = (Map<String, String>) response.getEntity();
-        assertEquals("Marca inactivada correctamente", responseBody.get("message"));
+        assertEquals("Marca desactivada correctamente", responseBody.get("message"));
         
         verify(er, times(1)).eliminarMarca(id);
     }

--- a/backend/src/test/java/codigocreativo/uy/servidorapp/ws/ModeloResourceTest.java
+++ b/backend/src/test/java/codigocreativo/uy/servidorapp/ws/ModeloResourceTest.java
@@ -111,7 +111,7 @@ class ModeloResourceTest {
         
         @SuppressWarnings("unchecked")
         Map<String, String> responseBody = (Map<String, String>) response.getEntity();
-        assertEquals("Modelo inactivado correctamente", responseBody.get("message"));
+        assertEquals("Modelo desactivado correctamente", responseBody.get("message"));
         
         verify(er, times(1)).eliminarModelos(id);
     }

--- a/backend/src/test/java/codigocreativo/uy/servidorapp/ws/PaisesResourceTest.java
+++ b/backend/src/test/java/codigocreativo/uy/servidorapp/ws/PaisesResourceTest.java
@@ -169,7 +169,7 @@ class PaisesResourceTest {
 
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         Map<String, String> entity = (Map<String, String>) response.getEntity();
-        assertEquals("País inactivado correctamente", entity.get("message"));
+        assertEquals("País desactivado correctamente", entity.get("message"));
         verify(er, times(1)).inactivarPais(1L);
     }
 

--- a/backend/src/test/java/codigocreativo/uy/servidorapp/ws/PerfilResourceTest.java
+++ b/backend/src/test/java/codigocreativo/uy/servidorapp/ws/PerfilResourceTest.java
@@ -113,7 +113,7 @@ class PerfilResourceTest {
         Response response = perfilResource.eliminarPerfil(id);
 
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-        assertEquals("{\"message\":\"Perfil inactivado correctamente\"}", response.getEntity());
+        assertEquals("{\"message\":\"Perfil desactivado correctamente\"}", response.getEntity());
         verify(perfilRemote, times(1)).obtenerPerfil(id);
         verify(perfilRemote, times(1)).eliminarPerfil(any(PerfilDto.class));
     }

--- a/backend/src/test/java/codigocreativo/uy/servidorapp/ws/ProveedoresResourceTest.java
+++ b/backend/src/test/java/codigocreativo/uy/servidorapp/ws/ProveedoresResourceTest.java
@@ -90,7 +90,7 @@ class ProveedoresResourceTest {
 
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         Map<String, String> entity = (Map<String, String>) response.getEntity();
-        assertEquals("Proveedor inactivado correctamente", entity.get("message"));
+        assertEquals("Proveedor desactivado correctamente", entity.get("message"));
         verify(er, times(1)).eliminarProveedor(1L);
     }
 

--- a/backend/src/test/java/codigocreativo/uy/servidorapp/ws/TipoEquipoResourceTest.java
+++ b/backend/src/test/java/codigocreativo/uy/servidorapp/ws/TipoEquipoResourceTest.java
@@ -125,7 +125,7 @@ class TipoEquipoResourceTest {
         
         @SuppressWarnings("unchecked")
         Map<String, String> responseBody = (Map<String, String>) response.getEntity();
-        assertEquals("Tipo de equipo inactivado correctamente", responseBody.get("message"));
+        assertEquals("Tipo de equipo desactivado correctamente", responseBody.get("message"));
         
         verify(er, times(1)).eliminarTiposEquipo(id);
     }

--- a/backend/src/test/java/codigocreativo/uy/servidorapp/ws/UsuarioResourceTest.java
+++ b/backend/src/test/java/codigocreativo/uy/servidorapp/ws/UsuarioResourceTest.java
@@ -383,7 +383,7 @@ class UsuarioResourceTest {
         Response response = usuarioResource.inactivarUsuario(idUsuario, token);
 
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-        assertEquals("{\"message\":\"Usuario inactivado correctamente\"}", response.getEntity());
+        assertEquals("{\"message\":\"Usuario desactivado correctamente\"}", response.getEntity());
         verify(usuarioRemote, times(1)).inactivarUsuario(anyString(), anyString());
     }
 

--- a/frontend/src/components/Paginas/TipoEquipos/Listar.tsx
+++ b/frontend/src/components/Paginas/TipoEquipos/Listar.tsx
@@ -72,7 +72,7 @@ const ListarTiposEquipos: React.FC = () => {
         method: "DELETE",
       });
       setShowDeleteModal(false);
-      (window as any).__resolveDelete({ message: "Tipo de equipo inactivado correctamente" });
+      (window as any).__resolveDelete({ message: "Tipo de equipo desactivado correctamente" });
       fetchTipos();
     } catch (err: any) {
       (window as any).__rejectDelete({ message: err.message || "Error al inactivar" });

--- a/frontend/src/components/Paginas/TiposIntervenciones/Listar.tsx
+++ b/frontend/src/components/Paginas/TiposIntervenciones/Listar.tsx
@@ -49,7 +49,7 @@ const ListarTiposIntervenciones: React.FC = () => {
     try {
       await fetcher(`/tipoIntervenciones/inactivar?id=${id}`, { method: "DELETE" });
       await handleSearch();
-      alert("Tipo de intervención inactivado correctamente");
+      alert("Tipo de intervención desactivado correctamente");
     } catch (err: any) {
       alert("Error al inactivar: " + err.message);
     }


### PR DESCRIPTION
## Summary
- update Spanish messaging to use "desactivado" instead of "inactivado"
- keep frontend alerts in sync
- update backend tests accordingly

## Testing
- `mvn -q test` *(fails: could not resolve org.jacoco:jacoco-maven-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6885fdc5749483249f55a811ee027f2c