### PR TITLE
Fix front filters and backend listing

### DIFF
--- a/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/TipoIntervencioneBean.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/TipoIntervencioneBean.java
@@ -23,7 +23,7 @@ public class TipoIntervencioneBean implements TipoIntervencioneRemote {
 
     @Override
     public List<TiposIntervencioneDto> obtenerTiposIntervenciones() {
-        List<TiposIntervencione> tiposIntervenciones = em.createQuery("SELECT t FROM TiposIntervencione t WHERE t.estado = 'ACTIVO'", TiposIntervencione.class).getResultList();
+        List<TiposIntervencione> tiposIntervenciones = em.createQuery("SELECT t FROM TiposIntervencione t", TiposIntervencione.class).getResultList();
         return tiposIntervencioneMapper.toDto(tiposIntervenciones);
     }
 

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/UbicacionBean.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/servicios/UbicacionBean.java
@@ -159,7 +159,7 @@ public class UbicacionBean implements UbicacionRemote {
     @Override
     public List<UbicacionDto> listarUbicaciones() throws ServiciosException {
         try {
-            List<Ubicacion> ubicaciones = em.createQuery("SELECT u FROM Ubicacion u WHERE u.estado = 'ACTIVO'", Ubicacion.class)
+            List<Ubicacion> ubicaciones = em.createQuery("SELECT u FROM Ubicacion u", Ubicacion.class)
                     .getResultList();
             return ubicacionMapper.toDto(ubicaciones);
         } catch (Exception e) {

--- a/backend/src/main/java/codigocreativo/uy/servidorapp/ws/UsuarioResource.java
+++ b/backend/src/main/java/codigocreativo/uy/servidorapp/ws/UsuarioResource.java
@@ -365,10 +365,8 @@ public class UsuarioResource {
             if (nombreUsuario != null && !nombreUsuario.isEmpty()) filtros.put("nombreUsuario", nombreUsuario);
             if (email != null && !email.isEmpty()) filtros.put(EMAIL, email);
 
-            // Filtro por estado: default "ACTIVO"
-            if (estado == null || estado.isEmpty()) {
-                filtros.put("estado", "ACTIVO");
-            } else if (!estado.equalsIgnoreCase("default")) {
+            // Filtro por estado
+            if (estado != null && !estado.isEmpty() && !estado.equalsIgnoreCase("default")) {
                 filtros.put("estado", estado);
             }
 

--- a/frontend/src/components/Paginas/Modelos/Listar.tsx
+++ b/frontend/src/components/Paginas/Modelos/Listar.tsx
@@ -49,8 +49,15 @@ const ListarModelos: React.FC = () => {
 
     // Filtrar por nombre
     if (filters.nombre) {
-      filteredData = filteredData.filter((modelo: Modelo) => 
+      filteredData = filteredData.filter((modelo: Modelo) =>
         modelo.nombre.toLowerCase().includes(filters.nombre.toLowerCase())
+      );
+    }
+
+    // Filtrar por marca
+    if (filters.marca) {
+      filteredData = filteredData.filter((modelo: Modelo) =>
+        modelo.idMarca?.nombre.toLowerCase().includes(filters.marca.toLowerCase())
       );
     }
 
@@ -63,7 +70,13 @@ const ListarModelos: React.FC = () => {
 
   const columns: Column<Modelo>[] = [
     { header: "Nombre", accessor: "nombre", type: "text", filterable: true },
-    { header: "Marca", accessor: (row) => row.idMarca?.nombre || "-", type: "text", filterable: false },
+    {
+      header: "Marca",
+      accessor: (row) => row.idMarca?.nombre || "-",
+      type: "text",
+      filterable: true,
+      filterKey: "marca",
+    },
     { header: "Estado", accessor: "estado", type: "text", filterable: true },
   ];
 

--- a/frontend/src/components/Paginas/Proveedores/Listar.tsx
+++ b/frontend/src/components/Paginas/Proveedores/Listar.tsx
@@ -1,6 +1,7 @@
 "use client";
-import React, { useState, useMemo } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import DynamicTable, { Column } from "@/components/Helpers/DynamicTable";
+import fetcher from "@/components/Helpers/Fetcher";
 
 interface Pais {
   id: number;
@@ -17,11 +18,57 @@ interface Proveedor {
 
 const ListarProveedores: React.FC = () => {
   const [proveedores, setProveedores] = useState<Proveedor[]>([]);
+  const [allProveedores, setAllProveedores] = useState<Proveedor[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const loadProveedores = async () => {
+    setLoading(true);
+    try {
+      const data = await fetcher<Proveedor[]>("/proveedores/listar", { method: "GET" });
+      setAllProveedores(data);
+      setProveedores(data.filter((p) => p.estado === "ACTIVO"));
+    } catch (err: any) {
+      setError(err.message);
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    loadProveedores();
+  }, []);
+
+  const handleSearch = (filters: Record<string, string>) => {
+    let data = allProveedores;
+
+    if (filters.estado) {
+      data = data.filter((p) => p.estado === filters.estado);
+    }
+
+    if (filters.nombre) {
+      data = data.filter((p) =>
+        p.nombre.toLowerCase().includes(filters.nombre.toLowerCase())
+      );
+    }
+
+    if (filters.pais) {
+      data = data.filter((p) =>
+        p.pais?.nombre.toLowerCase().includes(filters.pais.toLowerCase())
+      );
+    }
+
+    setProveedores(data);
+  };
 
   const columns: Column<Proveedor>[] = useMemo(() => [
     { header: "Nombre", accessor: "nombre", type: "text", filterable: true },
-    { header: "País", accessor: (row) => row.pais?.nombre || "-", type: "text", filterable: false },
+    {
+      header: "País",
+      accessor: (row) => row.pais?.nombre || "-",
+      type: "text",
+      filterable: true,
+      filterKey: "pais",
+    },
     { header: "Estado", accessor: "estado", type: "text", filterable: true }
   ], []);
 
@@ -30,14 +77,14 @@ const ListarProveedores: React.FC = () => {
       columns={columns}
       data={proveedores}
       withFilters={true}
+      onSearch={handleSearch}
       withActions={true}
-      filterUrl="/proveedores/filtrar"
       initialFilters={{ estado: "ACTIVO" }}
-      onDataUpdate={setProveedores}
       deleteUrl="/proveedores/inactivar"
       basePath="/proveedores"
       confirmDeleteMessage="¿Está seguro que desea dar de baja a este proveedor?"
       sendOnlyId={true}
+      onReload={loadProveedores}
     />
   );
 };

--- a/frontend/src/components/Paginas/Usuarios/Listar.tsx
+++ b/frontend/src/components/Paginas/Usuarios/Listar.tsx
@@ -105,7 +105,7 @@ const ListarUsuarios: React.FC = () => {
         data={usuarios}
         withFilters={true}
         filterUrl="/usuarios/filtrar"
-        initialFilters={{ estado: "ACTIVO" }}
+        initialFilters={{ estado: "" }}
         onDataUpdate={setUsuarios}
         withActions={true}
         deleteUrl="/usuarios/inactivar"


### PR DESCRIPTION
## Summary
- include brand filter for model listing
- add country filter for provider list and switch to local filtering
- return all locations and intervention types from backend
- allow filtering all users by default
- adjust user state filter handling on backend

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: dependency conflict)*
- `mvn -q test` *(fails: network unreachable while resolving jacoco)*

------
https://chatgpt.com/codex/tasks/task_e_68860ef24bf8832487e21eb73f3c782f